### PR TITLE
Link test http service mention to the docs

### DIFF
--- a/packages/content-management/README.md
+++ b/packages/content-management/README.md
@@ -128,6 +128,10 @@ const client = new ContentManagementClient({
 
 Online [API Reference](https://kentico.github.io/kentico-cloud-js/content-management) documents latest version of this library and can be used to quickly find all exposed methods and objects. Documentation is generated from `TypeScript` code and thus it should always be accurate.
 
+### Testing
+
+> If you want to mock http responses, it is possible to use [external implementation of configurable Http Service](../core/README.md#testing) as a part of the [client configuration](#configuration).
+
 ### Troubleshooting & feedback
 
 If you have any issues or want to share your feedback, please feel free to [create an issue](https://github.com/Kentico/kentico-cloud-js/issues/new/choose) in this GitHub repository.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,3 +2,10 @@
 # Core package
 
 This package contains core functionality used by dependant Kentico Cloud sdks such as Delivery or Content Management.
+
+# Testing
+
+If you want to inject testing service as an implementation of [IHttpService](lib/http/ihttp.service.ts), it is possible to use configurable [Kentico Cloud JS SDK Test Http Service](https://www.npmjs.com/package/kentico-cloud-js-sdk-test-http-service).
+
+
+

--- a/packages/delivery/DOCS.md
+++ b/packages/delivery/DOCS.md
@@ -822,7 +822,7 @@ deliveryClient
   });
 ```
 
-## Client configuration 
+## Client configuration
 
 Following is a list of configuration options for DeliveryClient (`IDeliveryClientConfig`):
 

--- a/packages/delivery/README.md
+++ b/packages/delivery/README.md
@@ -201,6 +201,8 @@ Note: You need to have `Chrome` installed in order to run tests via Karma.
 - `npm run test:dev` Runs developer tests (useful for testing functionality)
 - `npm run test:travis` Runs browser tests that are executed by travis
 
+> If you want to mock http responses, it is possible to use [external implementation of configurable Http Service](../core/README.md#testing) as a part of the [delivery client configuration](DOCS.md#client-configuration).
+
 ## Feedback & Contribution
 
 Feedback & Contributions are welcomed. Feel free to take/start an issue & submit PR.


### PR DESCRIPTION
### Motivation

Linking test http service possibility to the core and link this info from delivery and cm docs. As we agreed.

### Checklist

- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
