### PR TITLE
Renames methods in query builder to reflect what type, implements change workflow step & publish language variant API methods

### DIFF
--- a/packages/content-management/lib/client/content-management-client.class.ts
+++ b/packages/content-management/lib/client/content-management-client.class.ts
@@ -14,7 +14,7 @@ import {
     DeleteContentItemQuery,
     DeleteContentTypeQuery,
     DeleteTaxonomyQuery,
-    FullContentItemIdentifierQuery,
+    ContentItemIdentifierQuery,
     IdCodenameIdentifierQuery,
     LanguageIdentifierQuery,
     LanguageVariantElementsQuery,
@@ -38,6 +38,9 @@ import {
     ViewContentTypeQuery,
     ViewContentTypeSnippetQuery,
     ViewLanguageVariantQuery,
+    ChangeWorkflowStepOfLanguageOrVariantQuery,
+    PublishOrScheduleLanguageVariantQuery,
+    WorkflowStepIdentifierQuery,
 } from '../queries';
 import { sdkInfo } from '../sdk-info.generated';
 import { ContentManagementQueryService } from '../services';
@@ -62,6 +65,26 @@ export class ContentManagementClient implements IContentManagementClient {
             });
     }
 
+    changeWorkflowStepOfLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<WorkflowStepIdentifierQuery<ChangeWorkflowStepOfLanguageOrVariantQuery>>> {
+        return new ContentItemIdentifierQuery<LanguageIdentifierQuery<WorkflowStepIdentifierQuery<ChangeWorkflowStepOfLanguageOrVariantQuery>>>(
+            this.config, this.queryService, (
+                config, queryService, contentItemIdentifier) => new LanguageIdentifierQuery<WorkflowStepIdentifierQuery<ChangeWorkflowStepOfLanguageOrVariantQuery>>(
+                    config, queryService, (nConfig, nQueryService, languageIdentifier) => new WorkflowStepIdentifierQuery<ChangeWorkflowStepOfLanguageOrVariantQuery>(nConfig, nQueryService, (mConfig, mQueryservice, workflowIdentifier) => {
+                        return new ChangeWorkflowStepOfLanguageOrVariantQuery(config, queryService, contentItemIdentifier, languageIdentifier, workflowIdentifier);
+                    }
+                    )
+                ));
+    }
+
+    publishOrScheduleLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<PublishOrScheduleLanguageVariantQuery>> {
+        return new ContentItemIdentifierQuery<LanguageIdentifierQuery<PublishOrScheduleLanguageVariantQuery>>(
+            this.config, this.queryService, (
+                config, queryService, contentItemIdentifier) => new LanguageIdentifierQuery<PublishOrScheduleLanguageVariantQuery>(
+                    config, queryService, (nConfig, nQueryService, languageIdentifier) => new PublishOrScheduleLanguageVariantQuery(nConfig, nQueryService, contentItemIdentifier, languageIdentifier)
+                )
+        );
+    }
+
     listWorkflowSteps(): ListWorkflowStepsQuery {
         return new ListWorkflowStepsQuery(
             this.config,
@@ -84,8 +107,8 @@ export class ContentManagementClient implements IContentManagementClient {
         );
     }
 
-    viewLanguageVariant(): FullContentItemIdentifierQuery<LanguageIdentifierQuery<ViewLanguageVariantQuery>> {
-        return new FullContentItemIdentifierQuery<LanguageIdentifierQuery<ViewLanguageVariantQuery>>(
+    viewLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<ViewLanguageVariantQuery>> {
+        return new ContentItemIdentifierQuery<LanguageIdentifierQuery<ViewLanguageVariantQuery>>(
             this.config, this.queryService, (
                 config, queryService, contentItemIdentifier) => new LanguageIdentifierQuery<ViewLanguageVariantQuery>(
                     config, queryService, (nConfig, nQueryService, languageIdentifier) => new ViewLanguageVariantQuery(nConfig, nQueryService, contentItemIdentifier, languageIdentifier)
@@ -93,8 +116,8 @@ export class ContentManagementClient implements IContentManagementClient {
         );
     }
 
-    upsertLanguageVariant(): FullContentItemIdentifierQuery<LanguageIdentifierQuery<LanguageVariantElementsQuery<UpsertLanguageVariantQuery>>> {
-        return new FullContentItemIdentifierQuery<LanguageIdentifierQuery<LanguageVariantElementsQuery<UpsertLanguageVariantQuery>>>(
+    upsertLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<LanguageVariantElementsQuery<UpsertLanguageVariantQuery>>> {
+        return new ContentItemIdentifierQuery<LanguageIdentifierQuery<LanguageVariantElementsQuery<UpsertLanguageVariantQuery>>>(
             this.config, this.queryService, (
                 config, queryService, contentItemIdentifier) => new LanguageIdentifierQuery<LanguageVariantElementsQuery<UpsertLanguageVariantQuery>>(
                     config, queryService, (nConfig, nQueryService, languageIdentifier) => new LanguageVariantElementsQuery(nConfig, nQueryService, (
@@ -228,8 +251,8 @@ export class ContentManagementClient implements IContentManagementClient {
         );
     }
 
-    viewContentItem(): FullContentItemIdentifierQuery<ViewContentItemQuery> {
-        return new FullContentItemIdentifierQuery<ViewContentItemQuery>(
+    viewContentItem(): ContentItemIdentifierQuery<ViewContentItemQuery> {
+        return new ContentItemIdentifierQuery<ViewContentItemQuery>(
             this.config,
             this.queryService,
             (config, queryService, identifier) => new ViewContentItemQuery(config, queryService, identifier)
@@ -244,8 +267,8 @@ export class ContentManagementClient implements IContentManagementClient {
         );
     }
 
-    updateContentItem(): FullContentItemIdentifierQuery<DataQuery<UpdateContentItemQuery, ContentItemContracts.IUpdateContentItemPostContract>> {
-        return new FullContentItemIdentifierQuery<DataQuery<UpdateContentItemQuery, ContentItemContracts.IUpdateContentItemPostContract>>(
+    updateContentItem(): ContentItemIdentifierQuery<DataQuery<UpdateContentItemQuery, ContentItemContracts.IUpdateContentItemPostContract>> {
+        return new ContentItemIdentifierQuery<DataQuery<UpdateContentItemQuery, ContentItemContracts.IUpdateContentItemPostContract>>(
             this.config, this.queryService, (
                 config, queryService, identifier) => new DataQuery<UpdateContentItemQuery, ContentItemContracts.IUpdateContentItemPostContract>(
                     config, queryService, (nConfig, nQueryService, data) => new UpdateContentItemQuery(nConfig, nQueryService, data, identifier)
@@ -253,16 +276,16 @@ export class ContentManagementClient implements IContentManagementClient {
         );
     }
 
-    deleteContentItem(): FullContentItemIdentifierQuery<DeleteContentItemQuery> {
-        return new FullContentItemIdentifierQuery<DeleteContentItemQuery>(
+    deleteContentItem(): ContentItemIdentifierQuery<DeleteContentItemQuery> {
+        return new ContentItemIdentifierQuery<DeleteContentItemQuery>(
             this.config,
             this.queryService,
             (config, queryService, identifier) => new DeleteContentItemQuery(config, queryService, identifier)
         );
     }
 
-    listLanguageVariants(): FullContentItemIdentifierQuery<ListLanguageVariantsQuery> {
-        return new FullContentItemIdentifierQuery<ListLanguageVariantsQuery>(
+    listLanguageVariants(): ContentItemIdentifierQuery<ListLanguageVariantsQuery> {
+        return new ContentItemIdentifierQuery<ListLanguageVariantsQuery>(
             this.config,
             this.queryService,
             (config, queryService, identifier) => new ListLanguageVariantsQuery(config, queryService, identifier)

--- a/packages/content-management/lib/client/icontent-management-client.interface.ts
+++ b/packages/content-management/lib/client/icontent-management-client.interface.ts
@@ -6,12 +6,13 @@ import {
     AddContentTypeQuery,
     AddTaxonomyQuery,
     AssetIdentifierQueryClass,
+    ChangeWorkflowStepOfLanguageOrVariantQuery,
     DataQuery,
     DeleteAssetQuery,
     DeleteContentItemQuery,
     DeleteContentTypeQuery,
     DeleteTaxonomyQuery,
-    FullContentItemIdentifierQuery,
+    ContentItemIdentifierQuery,
     IdCodenameIdentifierQuery,
     LanguageIdentifierQuery,
     LanguageVariantElementsQuery,
@@ -23,6 +24,7 @@ import {
     ListTaxonomiesQuery,
     ListWorkflowStepsQuery,
     ProjectIdIdentifierQuery,
+    PublishOrScheduleLanguageVariantQuery,
     TaxonomyIdentifierQuery,
     UpdateAssetQuery,
     UpdateContentItemQuery,
@@ -35,9 +37,20 @@ import {
     ViewContentTypeQuery,
     ViewContentTypeSnippetQuery,
     ViewLanguageVariantQuery,
+    WorkflowStepIdentifierQuery,
 } from '../queries';
 
 export interface IContentManagementClient {
+
+    /**
+     * Change the workflow of the specified language variant to the specified workflow step. Equivalent to the UI operation of updating workflow.
+     */
+    changeWorkflowStepOfLanguageVariant():  ContentItemIdentifierQuery<LanguageIdentifierQuery<WorkflowStepIdentifierQuery<ChangeWorkflowStepOfLanguageOrVariantQuery>>>;
+
+    /**
+     * Change the workflow step of the specified language variant to "Published" or schedule publishing at the specified time.
+     */
+    publishOrScheduleLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<PublishOrScheduleLanguageVariantQuery>>;
 
     /**
      * Query to list all workflow steps in project
@@ -57,12 +70,12 @@ export interface IContentManagementClient {
     /**
      * Query to view language variant
      */
-    viewLanguageVariant(): FullContentItemIdentifierQuery<LanguageIdentifierQuery<ViewLanguageVariantQuery>>;
+    viewLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<ViewLanguageVariantQuery>>;
 
     /**
     * Query to upsert language variant
     */
-    upsertLanguageVariant(): FullContentItemIdentifierQuery<LanguageIdentifierQuery<LanguageVariantElementsQuery<UpsertLanguageVariantQuery>>>;
+    upsertLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<LanguageVariantElementsQuery<UpsertLanguageVariantQuery>>>;
 
     /**
      * Query to validate project content
@@ -147,7 +160,7 @@ export interface IContentManagementClient {
     /**
      * View content item query
      */
-    viewContentItem(): FullContentItemIdentifierQuery<ViewContentItemQuery>;
+    viewContentItem(): ContentItemIdentifierQuery<ViewContentItemQuery>;
 
     /**
     * Add content item query
@@ -157,15 +170,15 @@ export interface IContentManagementClient {
     /**
      * Update content item query
      */
-    updateContentItem(): FullContentItemIdentifierQuery<DataQuery<UpdateContentItemQuery, ContentItemContracts.IUpdateContentItemPostContract>>;
+    updateContentItem(): ContentItemIdentifierQuery<DataQuery<UpdateContentItemQuery, ContentItemContracts.IUpdateContentItemPostContract>>;
 
     /**
      * Delete content item query
      */
-    deleteContentItem(): FullContentItemIdentifierQuery<DeleteContentItemQuery>;
+    deleteContentItem(): ContentItemIdentifierQuery<DeleteContentItemQuery>;
 
     /**
      * List language variants query
      */
-    listLanguageVariants(): FullContentItemIdentifierQuery<ListLanguageVariantsQuery>;
+    listLanguageVariants(): ContentItemIdentifierQuery<ListLanguageVariantsQuery>;
 }

--- a/packages/content-management/lib/mappers/base-mapper.ts
+++ b/packages/content-management/lib/mappers/base-mapper.ts
@@ -29,5 +29,12 @@ export abstract class BaseMapper {
             id: rawReference.id
         });
     }
+
+    mapEmptyResponse(response: IBaseResponse<void | any>): BaseResponses.EmptyContentManagementResponse {
+        if (response.data) {
+            throw Error(`Expected response to be empty`);
+        }
+        return new BaseResponses.EmptyContentManagementResponse(this.mapResponseDebug(response), undefined, undefined);
+    }
 }
 

--- a/packages/content-management/lib/mappers/workflow-response-mapper.ts
+++ b/packages/content-management/lib/mappers/workflow-response-mapper.ts
@@ -16,10 +16,6 @@ export class WorkflowResponseMapper extends BaseMapper {
         return new WorkflowResponses.ListWorkflowStepsResponse(super.mapResponseDebug(response), response.data, workflowSteps);
     }
 
-    mapChangeWorkflowStepOfLanguageVariantResponse(response: IBaseResponse<void>): WorkflowResponses.ChangeWorkflowStepOfLanguageVariant {
-        return new WorkflowResponses.ChangeWorkflowStepOfLanguageVariant(super.mapResponseDebug(response), undefined, undefined);
-    }
-
     private mapWorkflowStep(rawStep: WorkflowContracts.IWorkflowStepContract): WorkflowModels.WorkflowStep {
         return new WorkflowModels.WorkflowStep({
             id: rawStep.id,

--- a/packages/content-management/lib/models/content-management-actions.ts
+++ b/packages/content-management/lib/models/content-management-actions.ts
@@ -7,6 +7,10 @@ class ContentManagementContentItemActions {
         return `items/${itemIdentifier.getParamValue()}/variants/${languageIdentifier.getParamValue()}/workflow/${workflowIdentifier.getParamValue()}`;
     }
 
+    publishOrScheduleLaguageVariant(itemIdentifier: Identifiers.ContentItemIdentifier, languageIdentifier: Identifiers.LanguageIdentifier): string {
+        return `items/${itemIdentifier.getParamValue()}/variants/${languageIdentifier.getParamValue()}/publish`;
+    }
+
     listWorkflowSteps(): string {
         return `workflow`;
     }

--- a/packages/content-management/lib/queries/query-builders/asset-identifier-query.class.ts
+++ b/packages/content-management/lib/queries/query-builders/asset-identifier-query.class.ts
@@ -18,7 +18,7 @@ export class AssetIdentifierQueryClass<TResult> {
     * Gets using internal Id
     * @param id Internal Id of content item
     */
-    byInternalId(id: string): TResult {
+    byAssetId(id: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.AssetIdentifier(Identifiers.AssetIdentifierEnum.InternalId, id));
     }
 
@@ -26,7 +26,7 @@ export class AssetIdentifierQueryClass<TResult> {
     * Gets query using external Id
     * @param id External Id of content item
     */
-    byExternalId(id: string): TResult {
+    byAssetExternalId(id: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.AssetIdentifier(Identifiers.AssetIdentifierEnum.ExternalId, id));
     }
 }

--- a/packages/content-management/lib/queries/query-builders/content-item-identifier-query.class.ts
+++ b/packages/content-management/lib/queries/query-builders/content-item-identifier-query.class.ts
@@ -2,7 +2,7 @@ import { IContentManagementClientConfig } from '../../config';
 import { Identifiers } from '../../models';
 import { ContentManagementQueryService } from '../../services';
 
-export class FullContentItemIdentifierQuery<TResult> {
+export class ContentItemIdentifierQuery<TResult> {
 
     constructor(
         protected config: IContentManagementClientConfig,
@@ -18,7 +18,7 @@ export class FullContentItemIdentifierQuery<TResult> {
     * Gets using internal Id
     * @param id Internal Id of content item
     */
-    byInternalId(id: string): TResult {
+    byItemId(id: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.ContentItemIdentifier(Identifiers.ContentItemIdentifierEnum.InternalId, id));
     }
 
@@ -26,7 +26,7 @@ export class FullContentItemIdentifierQuery<TResult> {
     * Gets query using external Id
     * @param id External Id of content item
     */
-    byExternalId(id: string): TResult {
+    byItemExternalId(id: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.ContentItemIdentifier(Identifiers.ContentItemIdentifierEnum.ExternalId, id));
     }
 
@@ -34,7 +34,7 @@ export class FullContentItemIdentifierQuery<TResult> {
     * Gets query using codename
     * @param codename Codename of content item
     */
-    byCodename(codename: string): TResult {
+    byItemCodename(codename: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.ContentItemIdentifier(Identifiers.ContentItemIdentifierEnum.Codename, codename));
     }
 }

--- a/packages/content-management/lib/queries/query-builders/id-and-external-id-identifier-query.class.ts
+++ b/packages/content-management/lib/queries/query-builders/id-and-external-id-identifier-query.class.ts
@@ -18,7 +18,7 @@ export class IdIdentifierQuery<TResult> {
     * Gets using internal Id
     * @param id Internal Id
     */
-    byInternalId(id: string): TResult {
+    byItemId(id: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.ContentItemIdentifier(Identifiers.ContentItemIdentifierEnum.InternalId, id));
     }
 
@@ -26,7 +26,7 @@ export class IdIdentifierQuery<TResult> {
     * Gets query using external Id
     * @param externalId External Id
     */
-    byExternalId(externalId: string): TResult {
+    byItemExternalId(externalId: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.ContentItemIdentifier(Identifiers.ContentItemIdentifierEnum.ExternalId, externalId));
     }
 }

--- a/packages/content-management/lib/queries/query-builders/id-codename-identifier-query.class.ts
+++ b/packages/content-management/lib/queries/query-builders/id-codename-identifier-query.class.ts
@@ -18,7 +18,7 @@ export class IdCodenameIdentifierQuery<TResult> {
     * Gets using internal Id
     * @param id Internal Id
     */
-    byInternalId(id: string): TResult {
+    byItemId(id: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.ContentItemIdentifier(Identifiers.ContentItemIdentifierEnum.InternalId, id));
     }
 
@@ -26,7 +26,7 @@ export class IdCodenameIdentifierQuery<TResult> {
     * Gets query using codename
     * @param codename Codename
     */
-    byCodename(codename: string): TResult {
+    byItemCodename(codename: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.ContentItemIdentifier(Identifiers.ContentItemIdentifierEnum.Codename, codename));
     }
 }

--- a/packages/content-management/lib/queries/query-builders/index.ts
+++ b/packages/content-management/lib/queries/query-builders/index.ts
@@ -1,4 +1,4 @@
-export * from './full-content-item-identifier-query.class';
+export * from './content-item-identifier-query.class';
 export * from './id-and-external-id-identifier-query.class';
 export * from './data-query.class';
 export * from './id-codename-identifier-query.class';
@@ -7,5 +7,5 @@ export * from './language-identifier-query.class';
 export * from './language-variant-elements-query.class';
 export * from './taxonomy-identifier-query.class';
 export * from './asset-identifier-query.class';
-
+export * from './workflow-step-identifier-query.class';
 

--- a/packages/content-management/lib/queries/query-builders/language-identifier-query.class.ts
+++ b/packages/content-management/lib/queries/query-builders/language-identifier-query.class.ts
@@ -18,7 +18,7 @@ export class LanguageIdentifierQuery<TResult> {
     * Gets using internal Id
     * @param id Internal Id
     */
-    forLanguageId(id: string): TResult {
+    byLanguageId(id: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.LanguageIdentifier(Identifiers.LanguageIdentifierEnum.InternalId, id));
     }
 
@@ -26,7 +26,7 @@ export class LanguageIdentifierQuery<TResult> {
     * Gets query using codename
     * @param codename Codename
     */
-    forLanguageCodename(codename: string): TResult {
+    byLanguageCodename(codename: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.LanguageIdentifier(Identifiers.LanguageIdentifierEnum.Codename, codename));
     }
 }

--- a/packages/content-management/lib/queries/query-builders/taxonomy-identifier-query.class.ts
+++ b/packages/content-management/lib/queries/query-builders/taxonomy-identifier-query.class.ts
@@ -18,7 +18,7 @@ export class TaxonomyIdentifierQuery<TResult> {
     * Gets using internal Id
     * @param id Internal Id of content item
     */
-    byInternalId(id: string): TResult {
+    byTaxonomyId(id: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.TaxonomyIdentifier(Identifiers.TaxonomyIdentifierEnum.InternalId, id));
     }
 
@@ -26,7 +26,7 @@ export class TaxonomyIdentifierQuery<TResult> {
     * Gets query using external Id
     * @param id External Id of content item
     */
-    byExternalId(id: string): TResult {
+    byTaxonomyExternalId(id: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.TaxonomyIdentifier(Identifiers.TaxonomyIdentifierEnum.ExternalId, id));
     }
 
@@ -34,7 +34,7 @@ export class TaxonomyIdentifierQuery<TResult> {
     * Gets query using codename
     * @param codename Codename of content item
     */
-    byCodename(codename: string): TResult {
+    byTaxonomyCodename(codename: string): TResult {
         return this.buildResult(this.config, this.queryService, new Identifiers.TaxonomyIdentifier(Identifiers.TaxonomyIdentifierEnum.Codename, codename));
     }
 }

--- a/packages/content-management/lib/queries/query-builders/workflow-step-identifier-query.class.ts
+++ b/packages/content-management/lib/queries/query-builders/workflow-step-identifier-query.class.ts
@@ -1,0 +1,25 @@
+import { IContentManagementClientConfig } from '../../config';
+import { Identifiers } from '../../models';
+import { ContentManagementQueryService } from '../../services';
+
+export class WorkflowStepIdentifierQuery<TResult> {
+
+    constructor(
+        protected config: IContentManagementClientConfig,
+        protected queryService: ContentManagementQueryService,
+        protected buildResult: (
+            config: IContentManagementClientConfig,
+            queryService: ContentManagementQueryService,
+            identifier: Identifiers.WorkflowIdentifier) => TResult
+    ) {
+    }
+
+    /**
+    * Id identifier
+    * @param id If of the workflow step
+    */
+    byWorkflowStepId(id: string): TResult {
+        return this.buildResult(this.config, this.queryService, new Identifiers.WorkflowIdentifier(Identifiers.WorkflowIdentifierEnum.Id, id));
+    }
+
+}

--- a/packages/content-management/lib/queries/workflow/index.ts
+++ b/packages/content-management/lib/queries/workflow/index.ts
@@ -1,2 +1,3 @@
 export * from './list-workflow-steps-query.class';
 export * from './change-workflow-step-of-language-variant-query.class';
+export * from './publish-or-schedule-language-variant-query.class';

--- a/packages/content-management/lib/queries/workflow/publish-or-schedule-language-variant-query.class.ts
+++ b/packages/content-management/lib/queries/workflow/publish-or-schedule-language-variant-query.class.ts
@@ -6,23 +6,22 @@ import { BaseResponses } from '../../responses';
 import { ContentManagementQueryService } from '../../services';
 import { BaseQuery } from '../base-query';
 
-export class ChangeWorkflowStepOfLanguageOrVariantQuery extends BaseQuery<BaseResponses.EmptyContentManagementResponse> {
+export class PublishOrScheduleLanguageVariantQuery extends BaseQuery<BaseResponses.EmptyContentManagementResponse> {
 
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
     protected contentItemIdentifier: Identifiers.ContentItemIdentifier,
     protected languageIdentifier: Identifiers.LanguageIdentifier,
-    protected workflowIdentifier: Identifiers.WorkflowIdentifier
   ) {
     super(config, queryService);
   }
 
   toObservable(): Observable<BaseResponses.EmptyContentManagementResponse> {
-    return this.queryService.changeWorkflowStepOfLanguageVariant(this.getUrl(), this.queryConfig);
+    return this.queryService.publishOrScheduleLanguageVariant(this.getUrl(), this.queryConfig);
   }
 
   protected getAction(): string {
-    return this.actions.contentItemActions.changeWorkflowStepOfLanguageVariant(this.contentItemIdentifier, this.languageIdentifier, this.workflowIdentifier);
+    return this.actions.contentItemActions.publishOrScheduleLaguageVariant(this.contentItemIdentifier, this.languageIdentifier);
   }
 }

--- a/packages/content-management/lib/responses/base-responses.ts
+++ b/packages/content-management/lib/responses/base-responses.ts
@@ -18,4 +18,14 @@ export namespace BaseResponses {
             public data: TData
         ) { }
     }
+
+    export class EmptyContentManagementResponse extends BaseResponses.BaseContentManagementResponse<void, void>  {
+        constructor(
+            debug: BaseResponses.IContentManagementResponseDebug,
+            rawData: void,
+            data: void
+        ) {
+            super(debug, rawData, data);
+        }
+    }
 }

--- a/packages/content-management/lib/responses/workflow/workflow-responses.ts
+++ b/packages/content-management/lib/responses/workflow/workflow-responses.ts
@@ -14,16 +14,6 @@ export namespace WorkflowResponses {
         }
     }
 
-    export class ChangeWorkflowStepOfLanguageVariant extends BaseResponses.BaseContentManagementResponse<void, void>  {
-        constructor(
-            debug: BaseResponses.IContentManagementResponseDebug,
-            rawData: void,
-            data: void
-        ) {
-            super(debug, rawData, data);
-        }
-    }
-
     export class PublishOrScheduleLanguageVariant extends BaseResponses.BaseContentManagementResponse<void, void>  {
         constructor(
             debug: BaseResponses.IContentManagementResponseDebug,

--- a/packages/content-management/lib/services/content-management-query-service.class.ts
+++ b/packages/content-management/lib/services/content-management-query-service.class.ts
@@ -39,6 +39,7 @@ import {
     ProjectResponses,
     TaxonomyResponses as TaxonomyResponses,
     WorkflowResponses,
+    BaseResponses,
 } from '../responses';
 import { BaseContentManagementQueryService } from './base-content-management-service.class';
 
@@ -52,17 +53,32 @@ export class ContentManagementQueryService extends BaseContentManagementQuerySer
         super(config, httpService, sdkInfo);
     }
 
-    changeWorkflowStepOfLanguageVariant(
+    publishOrScheduleLanguageVariant(
         url: string,
         config: IContentManagementQueryConfig
-    ): Observable<WorkflowResponses.ChangeWorkflowStepOfLanguageVariant> {
+    ): Observable<BaseResponses.EmptyContentManagementResponse> {
         return this.putResponse<void>(
             url,
             {},
             config,
         ).pipe(
             map(response => {
-                return workflowResponseMapper.mapChangeWorkflowStepOfLanguageVariantResponse(response);
+                return workflowResponseMapper.mapEmptyResponse(response);
+            })
+        );
+    }
+
+    changeWorkflowStepOfLanguageVariant(
+        url: string,
+        config: IContentManagementQueryConfig
+    ): Observable<BaseResponses.EmptyContentManagementResponse> {
+        return this.putResponse<void>(
+            url,
+            {},
+            config,
+        ).pipe(
+            map(response => {
+                return workflowResponseMapper.mapEmptyResponse(response);
             })
         );
     }

--- a/packages/content-management/test-browser/assets/delete-asset.spec.ts
+++ b/packages/content-management/test-browser/assets/delete-asset.spec.ts
@@ -6,7 +6,7 @@ describe('Delete asset', () => {
     let response: AssetResponses.DeleteAssetResponse;
 
     beforeAll((done) => {
-        getTestClientWithJson(deleteAssetJson).deleteAsset().byExternalId('xxx')
+        getTestClientWithJson(deleteAssetJson).deleteAsset().byAssetExternalId('xxx')
             .toObservable()
             .subscribe(result => {
                 response = result;
@@ -15,8 +15,8 @@ describe('Delete asset', () => {
     });
 
     it(`url should be correct`, () => {
-        const internalIdUrl = cmTestClient.deleteAsset().byInternalId('xInternalId').getUrl();
-        const externalIdUrl = cmTestClient.deleteAsset().byExternalId('xExternalId').getUrl();
+        const internalIdUrl = cmTestClient.deleteAsset().byAssetId('xInternalId').getUrl();
+        const externalIdUrl = cmTestClient.deleteAsset().byAssetExternalId('xExternalId').getUrl();
 
         expect(internalIdUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/assets/xInternalId`);
         expect(externalIdUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/assets/external-id/xExternalId`);

--- a/packages/content-management/test-browser/assets/view-asset.spec.ts
+++ b/packages/content-management/test-browser/assets/view-asset.spec.ts
@@ -7,7 +7,7 @@ describe('List assets', () => {
 
     beforeAll((done) => {
         getTestClientWithJson(viewAssetResponseJson).viewAsset()
-            .byInternalId('xxx')
+            .byAssetId('xxx')
             .toObservable()
             .subscribe(result => {
                 response = result;
@@ -16,8 +16,8 @@ describe('List assets', () => {
     });
 
     it(`url should be correct`, () => {
-        const internalIdUrl = cmTestClient.viewAsset().byInternalId('xInternalId').getUrl();
-        const externalIdUrl = cmTestClient.viewAsset().byExternalId('xExternalId').getUrl();
+        const internalIdUrl = cmTestClient.viewAsset().byAssetId('xInternalId').getUrl();
+        const externalIdUrl = cmTestClient.viewAsset().byAssetExternalId('xExternalId').getUrl();
 
         expect(internalIdUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/assets/xInternalId`);
         expect(externalIdUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/assets/external-id/xExternalId`);

--- a/packages/content-management/test-browser/content-items/delete-content-item.spec.ts
+++ b/packages/content-management/test-browser/content-items/delete-content-item.spec.ts
@@ -6,7 +6,7 @@ describe('Delete content item', () => {
     let response: ContentItemResponses.DeleteContentItemResponse;
 
     beforeAll((done) => {
-        getTestClientWithJson(deleteContentItemJson).deleteContentItem().byCodename('xxx')
+        getTestClientWithJson(deleteContentItemJson).deleteContentItem().byItemCodename('xxx')
             .toObservable()
             .subscribe(result => {
                 response = result;
@@ -15,9 +15,9 @@ describe('Delete content item', () => {
     });
 
     it(`url should be correct`, () => {
-        const codenameUrl = cmTestClient.deleteContentItem().byCodename('xCodename').getUrl();
-        const internalIdUrl = cmTestClient.deleteContentItem().byInternalId('xInternalId').getUrl();
-        const externalIdUrl = cmTestClient.deleteContentItem().byExternalId('xExternalId').getUrl();
+        const codenameUrl = cmTestClient.deleteContentItem().byItemCodename('xCodename').getUrl();
+        const internalIdUrl = cmTestClient.deleteContentItem().byItemId('xInternalId').getUrl();
+        const externalIdUrl = cmTestClient.deleteContentItem().byItemExternalId('xExternalId').getUrl();
 
         expect(codenameUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/codename/xCodename`);
         expect(internalIdUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/xInternalId`);

--- a/packages/content-management/test-browser/content-items/update-content-items.spec.ts
+++ b/packages/content-management/test-browser/content-items/update-content-items.spec.ts
@@ -7,7 +7,7 @@ describe('Update content item', () => {
 
     beforeAll((done) => {
         getTestClientWithJson(updateContentItemResponseJson).updateContentItem()
-            .byCodename('x')
+            .byItemCodename('x')
             .withData({
                 name: 'y',
                 sitemap_locations: [],
@@ -20,9 +20,9 @@ describe('Update content item', () => {
     });
 
     it(`url should be correct`, () => {
-        const codenameUrl = cmTestClient.updateContentItem().byCodename('xCodename').withData({} as any).getUrl();
-        const internalIdUrl = cmTestClient.updateContentItem().byInternalId('xInternalId').withData({} as any).getUrl();
-        const externalIdUrl = cmTestClient.updateContentItem().byExternalId('xExternalId').withData({} as any).getUrl();
+        const codenameUrl = cmTestClient.updateContentItem().byItemCodename('xCodename').withData({} as any).getUrl();
+        const internalIdUrl = cmTestClient.updateContentItem().byItemId('xInternalId').withData({} as any).getUrl();
+        const externalIdUrl = cmTestClient.updateContentItem().byItemExternalId('xExternalId').withData({} as any).getUrl();
 
         expect(codenameUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/codename/xCodename`);
         expect(internalIdUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/xInternalId`);

--- a/packages/content-management/test-browser/content-items/view-content-item.spec.ts
+++ b/packages/content-management/test-browser/content-items/view-content-item.spec.ts
@@ -6,7 +6,7 @@ describe('View content item', () => {
     let response: ContentItemResponses.ViewContentItemResponse;
 
     beforeAll((done) => {
-        getTestClientWithJson(viewContentItemJson).viewContentItem().byCodename(viewContentItemJson.codename)
+        getTestClientWithJson(viewContentItemJson).viewContentItem().byItemCodename(viewContentItemJson.codename)
             .toObservable()
             .subscribe(result => {
                 response = result;
@@ -15,9 +15,9 @@ describe('View content item', () => {
     });
 
     it(`url should be correct`, () => {
-        const codenameUrl = cmTestClient.viewContentItem().byCodename('xCodename').getUrl();
-        const internalIdUrl = cmTestClient.viewContentItem().byInternalId('xInternalId').getUrl();
-        const externalIdUrl = cmTestClient.viewContentItem().byExternalId('xExternalId').getUrl();
+        const codenameUrl = cmTestClient.viewContentItem().byItemCodename('xCodename').getUrl();
+        const internalIdUrl = cmTestClient.viewContentItem().byItemId('xInternalId').getUrl();
+        const externalIdUrl = cmTestClient.viewContentItem().byItemExternalId('xExternalId').getUrl();
 
         expect(codenameUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/codename/xCodename`);
         expect(internalIdUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/xInternalId`);

--- a/packages/content-management/test-browser/content-type-snippets/view-content-type-snippet.spec.ts
+++ b/packages/content-management/test-browser/content-type-snippets/view-content-type-snippet.spec.ts
@@ -8,7 +8,7 @@ describe('View content type snippet', () => {
 
     beforeAll((done) => {
         getTestClientWithJson(responseJson).viewContentTypeSnippet()
-            .byCodename('xxx')
+            .byItemCodename('xxx')
             .toObservable()
             .subscribe(result => {
                 response = result;
@@ -17,8 +17,8 @@ describe('View content type snippet', () => {
     });
 
     it(`url should be correct`, () => {
-        const urlByCodename = cmTestClient.viewContentTypeSnippet().byCodename('x').getUrl();
-        const urlByInternalId = cmTestClient.viewContentTypeSnippet().byInternalId('y').getUrl();
+        const urlByCodename = cmTestClient.viewContentTypeSnippet().byItemCodename('x').getUrl();
+        const urlByInternalId = cmTestClient.viewContentTypeSnippet().byItemId('y').getUrl();
 
         expect(urlByCodename).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/snippets/codename/x`);
         expect(urlByInternalId).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/snippets/y`);

--- a/packages/content-management/test-browser/content-types/delete-content-type.spec.ts
+++ b/packages/content-management/test-browser/content-types/delete-content-type.spec.ts
@@ -6,7 +6,7 @@ describe('Delete content type', () => {
     let response: ContentTypeResponses.DeleteContentTypeResponse;
 
     beforeAll((done) => {
-        getTestClientWithJson(deleteContentTypeJson).deleteContentType().byCodename('xxx')
+        getTestClientWithJson(deleteContentTypeJson).deleteContentType().byItemCodename('xxx')
             .toObservable()
             .subscribe(result => {
                 response = result;
@@ -15,8 +15,8 @@ describe('Delete content type', () => {
     });
 
     it(`url should be correct`, () => {
-        const codenameUrl = cmTestClient.deleteContentType().byCodename('xCodename').getUrl();
-        const internalIdUrl = cmTestClient.deleteContentType().byInternalId('xInternalId').getUrl();
+        const codenameUrl = cmTestClient.deleteContentType().byItemCodename('xCodename').getUrl();
+        const internalIdUrl = cmTestClient.deleteContentType().byItemId('xInternalId').getUrl();
 
         expect(codenameUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/types/codename/xCodename`);
         expect(internalIdUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/types/xInternalId`);

--- a/packages/content-management/test-browser/content-types/view-content-type.spec.ts
+++ b/packages/content-management/test-browser/content-types/view-content-type.spec.ts
@@ -8,7 +8,7 @@ describe('View content type', () => {
 
     beforeAll((done) => {
         getTestClientWithJson(viewContentTypeJson).viewContentType()
-            .byCodename('x')
+            .byItemCodename('x')
             .toObservable()
             .subscribe(result => {
                 response = result;
@@ -17,8 +17,8 @@ describe('View content type', () => {
     });
 
     it(`url should be correct`, () => {
-        const urlByCodename = cmTestClient.viewContentType().byCodename('x').getUrl();
-        const urlByInternalId = cmTestClient.viewContentType().byInternalId('y').getUrl();
+        const urlByCodename = cmTestClient.viewContentType().byItemCodename('x').getUrl();
+        const urlByInternalId = cmTestClient.viewContentType().byItemId('y').getUrl();
 
         expect(urlByCodename).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/types/codename/x`);
         expect(urlByInternalId).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/types/y`);

--- a/packages/content-management/test-browser/language-variants/list-language-variants.spec.ts
+++ b/packages/content-management/test-browser/language-variants/list-language-variants.spec.ts
@@ -8,7 +8,7 @@ describe('List language variants', () => {
 
     beforeAll((done) => {
         getTestClientWithJson(listLanguageVariantsJson).listLanguageVariants()
-            .byCodename('xxx')
+            .byItemCodename('xxx')
             .toObservable()
             .subscribe(result => {
                 response = result;
@@ -17,9 +17,9 @@ describe('List language variants', () => {
     });
 
     it(`url should be correct`, () => {
-        const codenameUrl = cmTestClient.listLanguageVariants().byCodename('xCodename').getUrl();
-        const internalIdUrl = cmTestClient.listLanguageVariants().byInternalId('xInternalId').getUrl();
-        const externalIdUrl = cmTestClient.listLanguageVariants().byExternalId('xExternalId').getUrl();
+        const codenameUrl = cmTestClient.listLanguageVariants().byItemCodename('xCodename').getUrl();
+        const internalIdUrl = cmTestClient.listLanguageVariants().byItemId('xInternalId').getUrl();
+        const externalIdUrl = cmTestClient.listLanguageVariants().byItemExternalId('xExternalId').getUrl();
 
         expect(codenameUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/codename/xCodename/variants`);
         expect(internalIdUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/xInternalId/variants`);

--- a/packages/content-management/test-browser/language-variants/upsert-language-variants.spec.ts
+++ b/packages/content-management/test-browser/language-variants/upsert-language-variants.spec.ts
@@ -8,8 +8,8 @@ describe('Upsert language variant', () => {
 
     beforeAll((done) => {
         getTestClientWithJson(jsonResponse).upsertLanguageVariant()
-            .byCodename('x')
-            .forLanguageCodename('x')
+            .byItemCodename('x')
+            .byLanguageCodename('x')
             .withElements([])
             .toObservable()
             .subscribe(result => {
@@ -19,13 +19,13 @@ describe('Upsert language variant', () => {
     });
 
     it(`url should be correct`, () => {
-        const codenameUrlWithCodenameLanguage = cmTestClient.upsertLanguageVariant().byCodename('xCodename').forLanguageCodename('xLanguageCodename').withElements([]).getUrl();
-        const internalIdUrlWithCodenameLanguage = cmTestClient.upsertLanguageVariant().byInternalId('xItemId').forLanguageCodename('xLanguageCodename').withElements([]).getUrl();
-        const externalIdUrlWithCodenameLanguage = cmTestClient.upsertLanguageVariant().byExternalId('XItemExternal').forLanguageCodename('xLanguageCodename').withElements([]).getUrl();
+        const codenameUrlWithCodenameLanguage = cmTestClient.upsertLanguageVariant().byItemCodename('xCodename').byLanguageCodename('xLanguageCodename').withElements([]).getUrl();
+        const internalIdUrlWithCodenameLanguage = cmTestClient.upsertLanguageVariant().byItemId('xItemId').byLanguageCodename('xLanguageCodename').withElements([]).getUrl();
+        const externalIdUrlWithCodenameLanguage = cmTestClient.upsertLanguageVariant().byItemExternalId('XItemExternal').byLanguageCodename('xLanguageCodename').withElements([]).getUrl();
 
-        const codenameUrlWithIdLanguage = cmTestClient.upsertLanguageVariant().byCodename('xCodename').forLanguageId('xLanguageId').withElements([]).getUrl();
-        const internalIdUrlWithIdLanguage = cmTestClient.upsertLanguageVariant().byInternalId('xItemId').forLanguageId('xLanguageId').withElements([]).getUrl();
-        const externalIdUrlWithIdLanguage = cmTestClient.upsertLanguageVariant().byExternalId('XItemExternal').forLanguageId('xLanguageId').withElements([]).getUrl();
+        const codenameUrlWithIdLanguage = cmTestClient.upsertLanguageVariant().byItemCodename('xCodename').byLanguageId('xLanguageId').withElements([]).getUrl();
+        const internalIdUrlWithIdLanguage = cmTestClient.upsertLanguageVariant().byItemId('xItemId').byLanguageId('xLanguageId').withElements([]).getUrl();
+        const externalIdUrlWithIdLanguage = cmTestClient.upsertLanguageVariant().byItemExternalId('XItemExternal').byLanguageId('xLanguageId').withElements([]).getUrl();
 
         expect(codenameUrlWithCodenameLanguage).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/codename/xCodename/variants/codename/xLanguageCodename`);
         expect(internalIdUrlWithCodenameLanguage).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/xItemId/variants/codename/xLanguageCodename`);

--- a/packages/content-management/test-browser/language-variants/view-language-variants.spec.ts
+++ b/packages/content-management/test-browser/language-variants/view-language-variants.spec.ts
@@ -8,8 +8,8 @@ describe('View language variant', () => {
 
     beforeAll((done) => {
         getTestClientWithJson(jsonResponse).viewLanguageVariant()
-            .byCodename('x')
-            .forLanguageCodename('x')
+            .byItemCodename('x')
+            .byLanguageCodename('x')
             .toObservable()
             .subscribe(result => {
                 response = result;
@@ -18,13 +18,13 @@ describe('View language variant', () => {
     });
 
     it(`url should be correct`, () => {
-        const codenameUrlWithCodenameLanguage = cmTestClient.viewLanguageVariant().byCodename('xCodename').forLanguageCodename('xLanguageCodename').getUrl();
-        const internalIdUrlWithCodenameLanguage = cmTestClient.viewLanguageVariant().byInternalId('xItemId').forLanguageCodename('xLanguageCodename').getUrl();
-        const externalIdUrlWithCodenameLanguage = cmTestClient.viewLanguageVariant().byExternalId('XItemExternal').forLanguageCodename('xLanguageCodename').getUrl();
+        const codenameUrlWithCodenameLanguage = cmTestClient.viewLanguageVariant().byItemCodename('xCodename').byLanguageCodename('xLanguageCodename').getUrl();
+        const internalIdUrlWithCodenameLanguage = cmTestClient.viewLanguageVariant().byItemId('xItemId').byLanguageCodename('xLanguageCodename').getUrl();
+        const externalIdUrlWithCodenameLanguage = cmTestClient.viewLanguageVariant().byItemExternalId('XItemExternal').byLanguageCodename('xLanguageCodename').getUrl();
 
-        const codenameUrlWithIdLanguage = cmTestClient.viewLanguageVariant().byCodename('xCodename').forLanguageId('xLanguageId').getUrl();
-        const internalIdUrlWithIdLanguage = cmTestClient.viewLanguageVariant().byInternalId('xItemId').forLanguageId('xLanguageId').getUrl();
-        const externalIdUrlWithIdLanguage = cmTestClient.viewLanguageVariant().byExternalId('XItemExternal').forLanguageId('xLanguageId').getUrl();
+        const codenameUrlWithIdLanguage = cmTestClient.viewLanguageVariant().byItemCodename('xCodename').byLanguageId('xLanguageId').getUrl();
+        const internalIdUrlWithIdLanguage = cmTestClient.viewLanguageVariant().byItemId('xItemId').byLanguageId('xLanguageId').getUrl();
+        const externalIdUrlWithIdLanguage = cmTestClient.viewLanguageVariant().byItemExternalId('XItemExternal').byLanguageId('xLanguageId').getUrl();
 
         expect(codenameUrlWithCodenameLanguage).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/codename/xCodename/variants/codename/xLanguageCodename`);
         expect(internalIdUrlWithCodenameLanguage).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/xItemId/variants/codename/xLanguageCodename`);

--- a/packages/content-management/test-browser/taxonomies/delete-taxonomy.spec.ts
+++ b/packages/content-management/test-browser/taxonomies/delete-taxonomy.spec.ts
@@ -7,7 +7,7 @@ describe('Delete taxonomy', () => {
     let response: TaxonomyResponses.DeleteTaxonomyResponse;
 
     beforeAll((done) => {
-        getTestClientWithJson(deleteTaxonomyJson).deleteTaxonomy().byCodename('xxx')
+        getTestClientWithJson(deleteTaxonomyJson).deleteTaxonomy().byTaxonomyCodename('xxx')
             .toObservable()
             .subscribe(result => {
                 response = result;
@@ -16,9 +16,9 @@ describe('Delete taxonomy', () => {
     });
 
     it(`url should be correct`, () => {
-        const codenameUrl = cmTestClient.deleteTaxonomy().byCodename('xCodename').getUrl();
-        const internalIdUrl = cmTestClient.deleteTaxonomy().byInternalId('xInternalId').getUrl();
-        const externalIdUrl = cmTestClient.deleteTaxonomy().byExternalId('xExternalId').getUrl();
+        const codenameUrl = cmTestClient.deleteTaxonomy().byTaxonomyCodename('xCodename').getUrl();
+        const internalIdUrl = cmTestClient.deleteTaxonomy().byTaxonomyId('xInternalId').getUrl();
+        const externalIdUrl = cmTestClient.deleteTaxonomy().byTaxonomyExternalId('xExternalId').getUrl();
 
         expect(codenameUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/taxonomies/codename/xCodename`);
         expect(internalIdUrl).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/taxonomies/xInternalId`);

--- a/packages/content-management/test-browser/workflow/change-workflow-step-of-language-variant.spec.ts
+++ b/packages/content-management/test-browser/workflow/change-workflow-step-of-language-variant.spec.ts
@@ -1,0 +1,38 @@
+import { BaseResponses } from '../../lib';
+import { cmTestClient, getTestClientWithJson, testProjectId } from '../setup';
+
+describe('Change workflow step of language variant', () => {
+    let response: BaseResponses.EmptyContentManagementResponse;
+
+    beforeAll((done) => {
+        getTestClientWithJson(undefined).changeWorkflowStepOfLanguageVariant()
+            .byItemCodename('x')
+            .byLanguageCodename('y')
+            .byWorkflowStepId('b')
+            .toObservable()
+            .subscribe(result => {
+                response = result;
+                done();
+            });
+    });
+
+    it(`url should be correct`, () => {
+        const w1Url = cmTestClient.changeWorkflowStepOfLanguageVariant().byItemCodename('x').byLanguageCodename('y').byWorkflowStepId('b').getUrl();
+
+        expect(w1Url).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/codename/x/variants/codename/y/workflow/b`);
+    });
+
+    it(`response should be instance of EmptyContentManagementResponse class`, () => {
+        expect(response).toEqual(jasmine.any(BaseResponses.EmptyContentManagementResponse));
+    });
+
+    it(`response should contain debug data`, () => {
+        expect(response.debug).toBeDefined();
+    });
+
+    it(`response should NOT contain data`, () => {
+        expect(response.data).toBeUndefined();
+    });
+
+});
+

--- a/packages/content-management/test-browser/workflow/publish-or-schedule-language-variant.spec.ts
+++ b/packages/content-management/test-browser/workflow/publish-or-schedule-language-variant.spec.ts
@@ -1,0 +1,37 @@
+import { BaseResponses } from '../../lib';
+import { cmTestClient, getTestClientWithJson, testProjectId } from '../setup';
+
+describe('Publish or schedule language variant', () => {
+    let response: BaseResponses.EmptyContentManagementResponse;
+
+    beforeAll((done) => {
+        getTestClientWithJson(undefined).publishOrScheduleLanguageVariant()
+            .byItemCodename('x')
+            .byLanguageCodename('y')
+            .toObservable()
+            .subscribe(result => {
+                response = result;
+                done();
+            });
+    });
+
+    it(`url should be correct`, () => {
+        const w1Url = cmTestClient.publishOrScheduleLanguageVariant().byItemCodename('x').byLanguageCodename('y').getUrl();
+
+        expect(w1Url).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/codename/x/variants/codename/y/publish`);
+    });
+
+    it(`response should be instance of EmptyContentManagementResponse class`, () => {
+        expect(response).toEqual(jasmine.any(BaseResponses.EmptyContentManagementResponse));
+    });
+
+    it(`response should contain debug data`, () => {
+        expect(response.debug).toBeDefined();
+    });
+
+    it(`response should NOT contain data`, () => {
+        expect(response.data).toBeUndefined();
+    });
+
+});
+


### PR DESCRIPTION
The main reason for changing the name of query builder method is to be clear about the type to achieve a query such as:

```
client.changeWorkflowStepOfLanguageVariant()
            .byItemCodename('x')
            .byLanguageCodename('y')
            .byWorkflowStepId('b')
            .toObservable()
```

Previously it would be possible to end up with query like:

```
client.changeWorkflowStepOfLanguageVariant()
            .byCodename('x')
            .byCodename('y')
            .byId('b')
            .toObservable()
```

which not ideal.