### PR TITLE
Adds support for specifying 'scheduled_to' data body param for publish or schedule to publish query), exposes data related properties for all queries

### DIFF
--- a/packages/content-management/lib/client/content-management-client.class.ts
+++ b/packages/content-management/lib/client/content-management-client.class.ts
@@ -2,20 +2,24 @@ import { HttpService } from 'kentico-cloud-core';
 
 import { IContentManagementClientConfig } from '../config';
 import { ContentItemContracts } from '../contracts';
-import { AssetModels, ContentTypeModels, TaxonomyModels, ContentTypeSnippetModels } from '../models';
+import { AssetModels, ContentTypeModels, ContentTypeSnippetModels, TaxonomyModels, WorkflowModels } from '../models';
 import {
     AddAssetQuery,
     AddContentItemQuery,
     AddContentTypeQuery,
+    AddContentTypeSnippetQuery,
     AddTaxonomyQuery,
     AssetIdentifierQueryClass,
+    CancelScheduledPublishingOfLanguageVariantQuery,
     ChangeWorkflowStepOfLanguageOrVariantQuery,
     ContentItemIdentifierQuery,
     ContentTypeIdentifierQuery,
+    CreateNewVersionOfLanguageVariantQuery,
     DataQuery,
     DeleteAssetQuery,
     DeleteContentItemQuery,
     DeleteContentTypeQuery,
+    DeleteContentTypeSnippetQuery,
     DeleteTaxonomyQuery,
     LanguageIdentifierQuery,
     LanguageVariantElementsQuery,
@@ -29,6 +33,7 @@ import {
     ProjectIdIdentifierQuery,
     PublishOrScheduleLanguageVariantQuery,
     TaxonomyIdentifierQuery,
+    UnpublishLanguageVariantQuery,
     UpdateAssetQuery,
     UpdateContentItemQuery,
     UploadBinaryFileQuery,
@@ -41,11 +46,6 @@ import {
     ViewContentTypeSnippetQuery,
     ViewLanguageVariantQuery,
     WorkflowStepIdentifierQuery,
-    DeleteContentTypeSnippetQuery,
-    AddContentTypeSnippetQuery,
-    CreateNewVersionOfLanguageVariantQuery,
-    UnpublishLanguageVariantQuery,
-    CancelScheduledPublishingOfLanguageVariantQuery,
 } from '../queries';
 import { sdkInfo } from '../sdk-info.generated';
 import { ContentManagementQueryService } from '../services';
@@ -108,12 +108,13 @@ export class ContentManagementClient implements IContentManagementClient {
                 ));
     }
 
-    publishOrScheduleLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<PublishOrScheduleLanguageVariantQuery>> {
-        return new ContentItemIdentifierQuery<LanguageIdentifierQuery<PublishOrScheduleLanguageVariantQuery>>(
+    publishOrScheduleLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<DataQuery<PublishOrScheduleLanguageVariantQuery, WorkflowModels.IPublishOrSchedulePublishData>>> {
+        return new ContentItemIdentifierQuery<LanguageIdentifierQuery<DataQuery<PublishOrScheduleLanguageVariantQuery, WorkflowModels.IPublishOrSchedulePublishData>>>(
             this.config, this.queryService, (
-                config, queryService, contentItemIdentifier) => new LanguageIdentifierQuery<PublishOrScheduleLanguageVariantQuery>(
-                    config, queryService, (nConfig, nQueryService, languageIdentifier) => new PublishOrScheduleLanguageVariantQuery(nConfig, nQueryService, contentItemIdentifier, languageIdentifier)
-                )
+                config, queryService, contentItemIdentifier) => new LanguageIdentifierQuery<DataQuery<PublishOrScheduleLanguageVariantQuery, WorkflowModels.IPublishOrSchedulePublishData>>(
+                    config, queryService, (nConfig, nQueryService, languageIdentifier) => new DataQuery<PublishOrScheduleLanguageVariantQuery, WorkflowModels.IPublishOrSchedulePublishData>(nConfig, nQueryService, (
+                        pConfig, pQueryService, data) => new PublishOrScheduleLanguageVariantQuery(pConfig, pQueryService, contentItemIdentifier, languageIdentifier, data)
+                    ))
         );
     }
 

--- a/packages/content-management/lib/client/icontent-management-client.interface.ts
+++ b/packages/content-management/lib/client/icontent-management-client.interface.ts
@@ -1,5 +1,5 @@
 import { ContentItemContracts } from '../contracts';
-import { AssetModels, ContentTypeModels, ContentTypeSnippetModels, TaxonomyModels } from '../models';
+import { AssetModels, ContentTypeModels, ContentTypeSnippetModels, TaxonomyModels, WorkflowModels } from '../models';
 import {
     AddAssetQuery,
     AddContentItemQuery,
@@ -7,9 +7,11 @@ import {
     AddContentTypeSnippetQuery,
     AddTaxonomyQuery,
     AssetIdentifierQueryClass,
+    CancelScheduledPublishingOfLanguageVariantQuery,
     ChangeWorkflowStepOfLanguageOrVariantQuery,
     ContentItemIdentifierQuery,
     ContentTypeIdentifierQuery,
+    CreateNewVersionOfLanguageVariantQuery,
     DataQuery,
     DeleteAssetQuery,
     DeleteContentItemQuery,
@@ -28,6 +30,7 @@ import {
     ProjectIdIdentifierQuery,
     PublishOrScheduleLanguageVariantQuery,
     TaxonomyIdentifierQuery,
+    UnpublishLanguageVariantQuery,
     UpdateAssetQuery,
     UpdateContentItemQuery,
     UploadBinaryFileQuery,
@@ -40,9 +43,6 @@ import {
     ViewContentTypeSnippetQuery,
     ViewLanguageVariantQuery,
     WorkflowStepIdentifierQuery,
-    CreateNewVersionOfLanguageVariantQuery,
-    UnpublishLanguageVariantQuery,
-    CancelScheduledPublishingOfLanguageVariantQuery,
 } from '../queries';
 
 export interface IContentManagementClient {
@@ -71,7 +71,7 @@ export interface IContentManagementClient {
     /**
      * Change the workflow step of the specified language variant to "Published" or schedule publishing at the specified time.
      */
-    publishOrScheduleLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<PublishOrScheduleLanguageVariantQuery>>;
+    publishOrScheduleLanguageVariant(): ContentItemIdentifierQuery<LanguageIdentifierQuery<DataQuery<PublishOrScheduleLanguageVariantQuery, WorkflowModels.IPublishOrSchedulePublishData>>>;
 
     /**
      * Query to list all workflow steps in project

--- a/packages/content-management/lib/models/workflow/workflow-models.ts
+++ b/packages/content-management/lib/models/workflow/workflow-models.ts
@@ -4,7 +4,7 @@ export namespace WorkflowModels {
 
         public id!: string;
         public name!: string;
-        transitionsTo!: string[];
+        public transitionsTo!: string[];
 
         constructor(data: {
             id: string,
@@ -13,6 +13,13 @@ export namespace WorkflowModels {
         }) {
             Object.assign(this, data);
         }
+    }
+
+    export interface IPublishOrSchedulePublishData {
+        /**
+         * ISO-8601 formatted date/time. Example: 2019-01-31T11:00:00+01:00
+         */
+        scheduled_to?: string;
     }
 
 }

--- a/packages/content-management/lib/queries/assets/add-asset-query.class.ts
+++ b/packages/content-management/lib/queries/assets/add-asset-query.class.ts
@@ -11,7 +11,7 @@ export class AddAssetQuery extends BaseQuery<AssetResponses.AddAssetResponse> {
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected data: AssetModels.IAddAssetRequestData,
+    public data: AssetModels.IAddAssetRequestData,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/assets/delete-asset-query.class.ts
+++ b/packages/content-management/lib/queries/assets/delete-asset-query.class.ts
@@ -11,7 +11,7 @@ export class DeleteAssetQuery extends BaseQuery<AssetResponses.DeleteAssetRespon
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected identifier: Identifiers.AssetIdentifier,
+    public identifier: Identifiers.AssetIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/assets/update-asset-query.class.ts
+++ b/packages/content-management/lib/queries/assets/update-asset-query.class.ts
@@ -11,7 +11,7 @@ export class UpdateAssetQuery extends BaseQuery<AssetResponses.UpdateAssetRespon
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected data: AssetModels.IUpdateAssetRequestData,
+    public data: AssetModels.IUpdateAssetRequestData,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/assets/upload-binary-file-query.class.ts
+++ b/packages/content-management/lib/queries/assets/upload-binary-file-query.class.ts
@@ -11,7 +11,7 @@ export class UploadBinaryFileQuery extends BaseQuery<AssetResponses.UploadBinary
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected data: AssetModels.IUploadBinaryFileRequestData,
+    public data: AssetModels.IUploadBinaryFileRequestData,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/assets/upsert-asset-query.class.ts
+++ b/packages/content-management/lib/queries/assets/upsert-asset-query.class.ts
@@ -11,7 +11,7 @@ export class UpsertAssetQuery extends BaseQuery<AssetResponses.UpdateAssetRespon
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected data: AssetModels.IUpsertAssetRequestData,
+    public data: AssetModels.IUpsertAssetRequestData,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/assets/view-assets-query.ts
+++ b/packages/content-management/lib/queries/assets/view-assets-query.ts
@@ -11,7 +11,7 @@ export class ViewAssetsQuery extends BaseQuery<AssetResponses.ViewAssetResponse>
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected identifier: Identifiers.AssetIdentifier,
+    public identifier: Identifiers.AssetIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/content-items/add-content-item-query.class.ts
+++ b/packages/content-management/lib/queries/content-items/add-content-item-query.class.ts
@@ -11,7 +11,7 @@ export class AddContentItemQuery extends BaseQuery<ContentItemResponses.AddConte
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected data: ContentItemContracts.IAddContentItemPostContract
+    public data: ContentItemContracts.IAddContentItemPostContract
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/content-items/delete-content-item-query.class.ts
+++ b/packages/content-management/lib/queries/content-items/delete-content-item-query.class.ts
@@ -11,7 +11,7 @@ export class DeleteContentItemQuery extends BaseQuery<ContentItemResponses.Delet
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected identifier: Identifiers.ContentItemIdentifier,
+    public identifier: Identifiers.ContentItemIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/content-items/update-content-item-query.class.ts
+++ b/packages/content-management/lib/queries/content-items/update-content-item-query.class.ts
@@ -12,8 +12,8 @@ export class UpdateContentItemQuery extends BaseQuery<ContentItemResponses.Updat
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected data: ContentItemContracts.IUpdateContentItemPostContract,
-    protected identifier: Identifiers.ContentItemIdentifier,
+    public data: ContentItemContracts.IUpdateContentItemPostContract,
+    public identifier: Identifiers.ContentItemIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/content-items/view-content-item-query.class.ts
+++ b/packages/content-management/lib/queries/content-items/view-content-item-query.class.ts
@@ -11,7 +11,7 @@ export class ViewContentItemQuery extends BaseQuery<ContentItemResponses.ViewCon
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected identifier: Identifiers.ContentItemIdentifier,
+    public identifier: Identifiers.ContentItemIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/content-type-snippets/add-content-type-snippet-query.class.ts
+++ b/packages/content-management/lib/queries/content-type-snippets/add-content-type-snippet-query.class.ts
@@ -11,7 +11,7 @@ export class AddContentTypeSnippetQuery extends BaseQuery<ContentTypeSnippetResp
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected data: ContentTypeSnippetModels.IAddContentTypeSnippetData,
+    public data: ContentTypeSnippetModels.IAddContentTypeSnippetData,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/content-type-snippets/delete-content-type-snippet-query.class.ts
+++ b/packages/content-management/lib/queries/content-type-snippets/delete-content-type-snippet-query.class.ts
@@ -11,7 +11,7 @@ export class DeleteContentTypeSnippetQuery extends BaseQuery<ContentTypeSnippetR
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected identifier: Identifiers.ContentTypeIdentifier,
+    public identifier: Identifiers.ContentTypeIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/content-type-snippets/view-content-type-snippet-query.class.ts
+++ b/packages/content-management/lib/queries/content-type-snippets/view-content-type-snippet-query.class.ts
@@ -11,7 +11,7 @@ export class ViewContentTypeSnippetQuery extends BaseQuery<ContentTypeSnippetRes
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected identifier: Identifiers.ContentTypeIdentifier,
+    public identifier: Identifiers.ContentTypeIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/content-types/add-content-type-query.class.ts
+++ b/packages/content-management/lib/queries/content-types/add-content-type-query.class.ts
@@ -11,7 +11,7 @@ export class AddContentTypeQuery extends BaseQuery<ContentTypeResponses.AddConte
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected data: ContentTypeModels.IAddContentTypeData,
+    public data: ContentTypeModels.IAddContentTypeData,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/content-types/delete-content-type-query.class.ts
+++ b/packages/content-management/lib/queries/content-types/delete-content-type-query.class.ts
@@ -11,7 +11,7 @@ export class DeleteContentTypeQuery extends BaseQuery<ContentTypeResponses.Delet
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected identifier: Identifiers.ContentTypeIdentifier,
+    public identifier: Identifiers.ContentTypeIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/content-types/view-content-type-query.class.ts
+++ b/packages/content-management/lib/queries/content-types/view-content-type-query.class.ts
@@ -11,7 +11,7 @@ export class ViewContentTypeQuery extends BaseQuery<ContentTypeResponses.ViewCon
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected identifier: Identifiers.ContentTypeIdentifier,
+    public identifier: Identifiers.ContentTypeIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/language-variants/upsert-language-variant-query.class.ts
+++ b/packages/content-management/lib/queries/language-variants/upsert-language-variant-query.class.ts
@@ -13,7 +13,7 @@ export class UpsertLanguageVariantQuery extends BaseQuery<LanguageVariantRespons
     protected queryService: ContentManagementQueryService,
     protected contentItemIdentifier: Identifiers.ContentItemIdentifier,
     protected languageIdentifier: Identifiers.LanguageIdentifier,
-    protected elements: LanguageVariantModels.ILanguageVariantElement[]
+    public elements: LanguageVariantModels.ILanguageVariantElement[]
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/language-variants/view-language-variant-query.class.ts
+++ b/packages/content-management/lib/queries/language-variants/view-language-variant-query.class.ts
@@ -11,8 +11,8 @@ export class ViewLanguageVariantQuery extends BaseQuery<LanguageVariantResponses
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected contentItemIdentifier: Identifiers.ContentItemIdentifier,
-    protected languageIdentifier: Identifiers.LanguageIdentifier,
+    public contentItemIdentifier: Identifiers.ContentItemIdentifier,
+    public languageIdentifier: Identifiers.LanguageIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/projects/validate-project-content-query.ts
+++ b/packages/content-management/lib/queries/projects/validate-project-content-query.ts
@@ -10,7 +10,7 @@ export class ValidateProjectContentQuery extends BaseQuery<ProjectResponses.Vali
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected projectId: string,
+    public projectId: string,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/taxonomies/add-taxonomy-query.class.ts
+++ b/packages/content-management/lib/queries/taxonomies/add-taxonomy-query.class.ts
@@ -11,7 +11,7 @@ export class AddTaxonomyQuery extends BaseQuery<TaxonomyResponses.AddTaxonomyRes
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected data: TaxonomyModels.IAddTaxonomyRequestModel
+    public data: TaxonomyModels.IAddTaxonomyRequestModel
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/taxonomies/delete-taxonomy-query.class.ts
+++ b/packages/content-management/lib/queries/taxonomies/delete-taxonomy-query.class.ts
@@ -11,7 +11,7 @@ export class DeleteTaxonomyQuery extends BaseQuery<TaxonomyResponses.DeleteTaxon
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected identifier: Identifiers.TaxonomyIdentifier,
+    public identifier: Identifiers.TaxonomyIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/workflow/cancel-scheduled-publishing-of-language-variant-query.class.ts
+++ b/packages/content-management/lib/queries/workflow/cancel-scheduled-publishing-of-language-variant-query.class.ts
@@ -11,8 +11,8 @@ export class CancelScheduledPublishingOfLanguageVariantQuery extends BaseQuery<B
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected contentItemIdentifier: Identifiers.ContentItemIdentifier,
-    protected languageIdentifier: Identifiers.LanguageIdentifier,
+    public contentItemIdentifier: Identifiers.ContentItemIdentifier,
+    public languageIdentifier: Identifiers.LanguageIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/workflow/change-workflow-step-of-language-variant-query.class.ts
+++ b/packages/content-management/lib/queries/workflow/change-workflow-step-of-language-variant-query.class.ts
@@ -11,9 +11,9 @@ export class ChangeWorkflowStepOfLanguageOrVariantQuery extends BaseQuery<BaseRe
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected contentItemIdentifier: Identifiers.ContentItemIdentifier,
-    protected languageIdentifier: Identifiers.LanguageIdentifier,
-    protected workflowIdentifier: Identifiers.WorkflowIdentifier
+    public contentItemIdentifier: Identifiers.ContentItemIdentifier,
+    public languageIdentifier: Identifiers.LanguageIdentifier,
+    public workflowIdentifier: Identifiers.WorkflowIdentifier
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/workflow/create-new-version-of-language-variant-query.class.ts
+++ b/packages/content-management/lib/queries/workflow/create-new-version-of-language-variant-query.class.ts
@@ -11,8 +11,8 @@ export class CreateNewVersionOfLanguageVariantQuery extends BaseQuery<BaseRespon
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected contentItemIdentifier: Identifiers.ContentItemIdentifier,
-    protected languageIdentifier: Identifiers.LanguageIdentifier,
+    public contentItemIdentifier: Identifiers.ContentItemIdentifier,
+    public languageIdentifier: Identifiers.LanguageIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/queries/workflow/publish-or-schedule-language-variant-query.class.ts
+++ b/packages/content-management/lib/queries/workflow/publish-or-schedule-language-variant-query.class.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 
 import { IContentManagementClientConfig } from '../../config';
-import { Identifiers } from '../../models';
+import { Identifiers, WorkflowModels } from '../../models';
 import { BaseResponses } from '../../responses';
 import { ContentManagementQueryService } from '../../services';
 import { BaseQuery } from '../base-query';
@@ -11,14 +11,15 @@ export class PublishOrScheduleLanguageVariantQuery extends BaseQuery<BaseRespons
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected contentItemIdentifier: Identifiers.ContentItemIdentifier,
-    protected languageIdentifier: Identifiers.LanguageIdentifier,
+    public contentItemIdentifier: Identifiers.ContentItemIdentifier,
+    public languageIdentifier: Identifiers.LanguageIdentifier,
+    public data: WorkflowModels.IPublishOrSchedulePublishData
   ) {
     super(config, queryService);
   }
 
   toObservable(): Observable<BaseResponses.EmptyContentManagementResponse> {
-    return this.queryService.publishOrScheduleLanguageVariant(this.getUrl(), this.queryConfig);
+    return this.queryService.publishOrScheduleLanguageVariant(this.getUrl(), this.data, this.queryConfig);
   }
 
   protected getAction(): string {

--- a/packages/content-management/lib/queries/workflow/unpublish-language-variant-query.class.ts
+++ b/packages/content-management/lib/queries/workflow/unpublish-language-variant-query.class.ts
@@ -11,8 +11,8 @@ export class UnpublishLanguageVariantQuery extends BaseQuery<BaseResponses.Empty
   constructor(
     protected config: IContentManagementClientConfig,
     protected queryService: ContentManagementQueryService,
-    protected contentItemIdentifier: Identifiers.ContentItemIdentifier,
-    protected languageIdentifier: Identifiers.LanguageIdentifier,
+    public contentItemIdentifier: Identifiers.ContentItemIdentifier,
+    public languageIdentifier: Identifiers.LanguageIdentifier,
   ) {
     super(config, queryService);
   }

--- a/packages/content-management/lib/services/content-management-query-service.class.ts
+++ b/packages/content-management/lib/services/content-management-query-service.class.ts
@@ -30,6 +30,7 @@ import {
     IContentManagementQueryConfig,
     LanguageVariantModels,
     TaxonomyModels,
+    WorkflowModels,
 } from '../models';
 import {
     AssetResponses,
@@ -56,11 +57,12 @@ export class ContentManagementQueryService extends BaseContentManagementQuerySer
 
     publishOrScheduleLanguageVariant(
         url: string,
+        data: WorkflowModels.IPublishOrSchedulePublishData,
         config: IContentManagementQueryConfig
     ): Observable<BaseResponses.EmptyContentManagementResponse> {
         return this.putResponse<void>(
             url,
-            undefined,
+            data,
             {},
             config,
         ).pipe(

--- a/packages/content-management/test-browser/workflow/publish-or-schedule-language-variant.spec.ts
+++ b/packages/content-management/test-browser/workflow/publish-or-schedule-language-variant.spec.ts
@@ -1,23 +1,31 @@
-import { BaseResponses } from '../../lib';
+import { BaseResponses, PublishOrScheduleLanguageVariantQuery } from '../../lib';
 import { cmTestClient, getTestClientWithJson, testProjectId } from '../setup';
 
 describe('Publish or schedule language variant', () => {
     let response: BaseResponses.EmptyContentManagementResponse;
+    let query: PublishOrScheduleLanguageVariantQuery;
 
     beforeAll((done) => {
-        getTestClientWithJson(undefined).publishOrScheduleLanguageVariant()
+     query = getTestClientWithJson(undefined).publishOrScheduleLanguageVariant()
             .byItemCodename('x')
             .byLanguageCodename('y')
-            .toObservable()
+            .withData({
+                scheduled_to: '2019-01-31T11:00:00+01:00'
+            });
+
+            query.toObservable()
             .subscribe(result => {
                 response = result;
                 done();
             });
     });
 
-    it(`url should be correct`, () => {
-        const w1Url = cmTestClient.publishOrScheduleLanguageVariant().byItemCodename('x').byLanguageCodename('y').getUrl();
+    it(`query data should be set`, () => {
+        expect(query.data.scheduled_to).toEqual(`2019-01-31T11:00:00+01:00`);
+    });
 
+    it(`url should be correct`, () => {
+        const w1Url = cmTestClient.publishOrScheduleLanguageVariant().byItemCodename('x').byLanguageCodename('y').withData({}).getUrl();
         expect(w1Url).toEqual(`https://manage.kenticocloud.com/v2/projects/${testProjectId}/items/codename/x/variants/codename/y/publish`);
     });
 


### PR DESCRIPTION
…h or schedule to publish query (https://github.com/Kentico/kentico-cloud-js/issues/161), exposes data related properties for all queries

### Motivation

Which issue does this fix? Fixes #`issue number`

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
