### PR TITLE
Refactors delivery item strongly typed resolver, sets default item type to 'IContentItem'

### DIFF
--- a/packages/delivery/lib/mappers/item.mapper.ts
+++ b/packages/delivery/lib/mappers/item.mapper.ts
@@ -1,18 +1,18 @@
 import { IDeliveryClientConfig } from '../config';
 import { ItemContracts } from '../data-contracts';
-import { IItemQueryConfig } from '../interfaces';
+import { IContentItem, IItemQueryConfig } from '../interfaces';
 import { FieldMapper } from '../mappers';
-import { ContentItem, IContentItemsContainer } from '../models';
+import { IContentItemsContainer } from '../models';
 import { IRichTextHtmlParser } from '../parser';
 
-export interface MapItemResult<TItem extends ContentItem> {
+export interface MapItemResult<TItem extends IContentItem = IContentItem> {
     item: TItem;
     processedItems: IContentItemsContainer;
     preparedItems: IContentItemsContainer;
     processingStartedForCodenames: string[];
 }
 
-export interface MapItemsResult<TItem extends ContentItem> {
+export interface MapItemsResult<TItem extends IContentItem = IContentItem> {
     items: TItem[];
     processedItems: IContentItemsContainer;
     preparedItems: IContentItemsContainer;
@@ -35,7 +35,7 @@ export class ItemMapper {
      * @param response Cloud response used to map the item
      * @param queryConfig Query configuration
      */
-    mapSingleItem<TItem extends ContentItem>(response: ItemContracts.IItemResponseContract, queryConfig: IItemQueryConfig): MapItemResult<TItem> {
+    mapSingleItem<TItem extends IContentItem = IContentItem>(response: ItemContracts.IItemResponseContract, queryConfig: IItemQueryConfig): MapItemResult<TItem> {
         return this.mapItem<TItem>({
             item: response.item,
             modularContent: response.modular_content,
@@ -51,7 +51,7 @@ export class ItemMapper {
     * @param response Cloud response used to map the item
     * @param queryConfig Query configuration
     */
-    mapMultipleItems<TItem extends ContentItem>(response: ItemContracts.IItemsResponseContract, queryConfig: IItemQueryConfig): MapItemsResult<TItem> {
+    mapMultipleItems<TItem extends IContentItem = IContentItem>(response: ItemContracts.IItemsResponseContract, queryConfig: IItemQueryConfig): MapItemsResult<TItem> {
         const that = this;
 
         const processedItems: IContentItemsContainer = {};
@@ -79,7 +79,7 @@ export class ItemMapper {
         };
     }
 
-    private mapItem<TItem extends ContentItem>(data: {
+    private mapItem<TItem extends IContentItem = IContentItem>(data: {
         item: ItemContracts.IContentItemContract,
         modularContent: ItemContracts.IModularContentWrapperContract,
         queryConfig: IItemQueryConfig,

--- a/packages/delivery/lib/mappers/response.mapper.ts
+++ b/packages/delivery/lib/mappers/response.mapper.ts
@@ -2,7 +2,7 @@ import { IBaseResponse } from 'kentico-cloud-core';
 
 import { IDeliveryClientConfig } from '../config';
 import { ElementContracts, ItemContracts, TaxonomyContracts, TypeContracts } from '../data-contracts';
-import { ICloudResponseDebug, IItemQueryConfig } from '../interfaces';
+import { ICloudResponseDebug, IItemQueryConfig, IContentItem } from '../interfaces';
 import { ContentItem, ElementResponses, ItemResponses, Pagination, TaxonomyResponses, TypeResponses } from '../models';
 import { IRichTextHtmlParser } from '../parser';
 import { ElementMapper } from './element.mapper';
@@ -75,7 +75,7 @@ export class ResponseMapper {
    * @param response Response data
    * @param queryConfig Query configuration
    */
-  mapSingleResponse<TItem extends ContentItem>(
+  mapSingleResponse<TItem extends IContentItem = IContentItem>(
     response: IBaseResponse<ItemContracts.IItemResponseContract>,
     queryConfig: IItemQueryConfig
   ): ItemResponses.DeliveryItemResponse<TItem> {
@@ -86,7 +86,7 @@ export class ResponseMapper {
       queryConfig
     );
 
-    return new ItemResponses.DeliveryItemResponse(
+    return new ItemResponses.DeliveryItemResponse<TItem>(
       itemResult.item,
       itemResult.processedItems,
       this.mapResponseDebug(response)
@@ -98,7 +98,7 @@ export class ResponseMapper {
    * @param response Response data
    * @param queryConfig Query configuration
    */
-  mapMultipleResponse<TItem extends ContentItem>(
+  mapMultipleResponse<TItem extends IContentItem = IContentItem>(
     response: IBaseResponse<ItemContracts.IItemsResponseContract>,
     queryConfig: IItemQueryConfig
   ): ItemResponses.DeliveryItemListingResponse<TItem> {
@@ -117,7 +117,7 @@ export class ResponseMapper {
       nextPage: response.data.pagination.next_page
     });
 
-    return new ItemResponses.DeliveryItemListingResponse(
+    return new ItemResponses.DeliveryItemListingResponse<TItem>(
       itemsResult.items,
       pagination,
       itemsResult.processedItems,

--- a/packages/delivery/lib/models/item/i-content-items-container.interface.ts
+++ b/packages/delivery/lib/models/item/i-content-items-container.interface.ts
@@ -1,5 +1,5 @@
-import { ContentItem } from './content-item.class';
+import { IContentItem } from '../../interfaces';
 
-export interface IContentItemsContainer {
-    [key: string]: ContentItem;
+export interface IContentItemsContainer<TItem extends IContentItem = IContentItem> {
+    [key: string]: TItem;
 }

--- a/packages/delivery/lib/models/item/index.ts
+++ b/packages/delivery/lib/models/item/index.ts
@@ -5,4 +5,5 @@ export * from './responses';
 export * from './image.class';
 export * from './item-resolvers';
 export * from './i-content-items-container.interface';
+export * from './type-resolver.class';
 

--- a/packages/delivery/lib/models/item/item-resolvers.ts
+++ b/packages/delivery/lib/models/item/item-resolvers.ts
@@ -9,22 +9,6 @@ import { ContentItem } from './content-item.class';
 import { RichTextImage } from './image.class';
 import { Link } from './link.class';
 
-export class TypeResolver {
-
-    /**
-    * Resolver used to create empty instance of object representing your content item.
-    * For example if you create a class 'Character' which corresponds to 'character' code name of Kentico Cloud type, you
-    * need to use TypeResolver like: 'new TypeResolver("code_example", () => new CodeExample())'
-    * @constructor
-    * @param {string} type - Codename of the content item defined in your Kentico Cloud content types
-    * @param {() => ContentItem} resolve - Calbacked used to returs empty instance of proper item class
-    */
-    constructor(
-        public type: string,
-        public resolve: () => ContentItem
-    ) { }
-}
-
 export type ItemFieldCollisionResolver = (fieldName: string) => string;
 export type ItemPropertyResolver = (fieldName: string) => string;
 export type ItemLinkResolver = (link: Link, context: ILinkResolverContext) => string | ILinkResolverResult;

--- a/packages/delivery/lib/models/item/responses.ts
+++ b/packages/delivery/lib/models/item/responses.ts
@@ -1,12 +1,12 @@
+import { IContentItem } from '../../interfaces';
 import { ICloudResponseDebug } from '../../interfaces/common/icloud-response-debug.interface';
 import { ICloudResponse } from '../../interfaces/common/icloud-response.interface';
 import { Pagination } from '../common';
-import { ContentItem } from './content-item.class';
 import { IContentItemsContainer } from './i-content-items-container.interface';
 
 export namespace ItemResponses {
 
-    export class DeliveryItemListingResponse<TItem extends ContentItem> implements ICloudResponse {
+    export class DeliveryItemListingResponse<TItem extends IContentItem = IContentItem> implements ICloudResponse {
 
         /**
          * Indicates if response contains any items
@@ -74,7 +74,7 @@ export namespace ItemResponses {
         }
     }
 
-    export class DeliveryItemResponse<TItem extends ContentItem> implements ICloudResponse {
+    export class DeliveryItemResponse<TItem extends IContentItem = IContentItem> implements ICloudResponse {
 
         /**
          * Indicates if response contains item

--- a/packages/delivery/lib/models/item/type-resolver.class.ts
+++ b/packages/delivery/lib/models/item/type-resolver.class.ts
@@ -1,0 +1,18 @@
+import { ContentItem } from './content-item.class';
+
+export class TypeResolver {
+
+    /**
+    * Resolver used to create instance of particular class representing your content item. This is useful if you want to access
+    * properties in a strongly types manner when using TypeScript or to define additional properties/functions on the class.
+    * For example if you create a class 'Character' which corresponds to 'character' code name of Kentico Cloud type, you
+    * typically register it like: 'new TypeResolver("code_example", () => new CodeExample())'
+    * @constructor
+    * @param {string} type - Codename of the content item defined in your Kentico Cloud content types
+    * @param {() => ContentItem} resolve - Function used create new instance of your class
+    */
+    constructor(
+        public type: string,
+        public resolve: () => ContentItem
+    ) { }
+}

--- a/packages/delivery/lib/resolvers/rich-text.resolver.ts
+++ b/packages/delivery/lib/resolvers/rich-text.resolver.ts
@@ -1,5 +1,5 @@
 import { RichTextContentType } from '../enums';
-import { IItemQueryConfig, ILinkResolverContext, ILinkResolverResult, IRichTextImageResolverResult } from '../interfaces';
+import { IItemQueryConfig, ILinkResolverContext, ILinkResolverResult, IRichTextImageResolverResult, IContentItem } from '../interfaces';
 import { ContentItem, ItemRichTextResolver, Link, RichTextImage, TypeResolver } from '../models';
 import { IHtmlResolverConfig, IRichTextHtmlParser } from '../parser';
 import { stronglyTypedResolver } from './delivery-item-strongly-type.resolver';
@@ -184,7 +184,7 @@ export class RichTextResolver {
 
         if (!url) {
             // url was not resolved, try to find global resolver for this particular type
-            const emptyTypedItem = stronglyTypedResolver.createEmptyTypedObj<ContentItem>(link.type, data.typeResolvers);
+            const emptyTypedItem = stronglyTypedResolver.createDummyInstance(link.type, data.typeResolvers);
 
             if (!emptyTypedItem) {
                 if (data.config.enableAdvancedLogging) {

--- a/packages/delivery/test-browser/isolated-tests/services/delivery-item-strongly-type-resolver.spec.ts
+++ b/packages/delivery/test-browser/isolated-tests/services/delivery-item-strongly-type-resolver.spec.ts
@@ -6,11 +6,6 @@ describe('Delivery strongly type resolver', () => {
     const context = new Context();
     setup(context);
 
-    it(`Should throw an Error when invalid response is given`, () => {
-        expect(() => stronglyTypedResolver.createEmptyTypedObj(null as any, context.typeResolvers)).toThrowError();
-        expect(() => stronglyTypedResolver.createEmptyTypedObj(undefined as any, context.typeResolvers)).toThrowError();
-    });
-
     it(`System properties should be mapped`, () => {
 
         const systemAttributes = stronglyTypedResolver.mapSystemAttributes({

--- a/packages/delivery/test-browser/live-tests/item/live-item.spec.ts
+++ b/packages/delivery/test-browser/live-tests/item/live-item.spec.ts
@@ -24,7 +24,7 @@ describe('Live item', () => {
       })
       .toObservable()
       .subscribe(r => {
-        response = r as ItemResponses.DeliveryItemResponse<Movie>;
+        response = r;
         done();
       });
   });


### PR DESCRIPTION
This PR also enables the use of Delivery item responses without specifying Type as it defaults to `IContentItem`. 

Performance is slightly improved as `typeResolver` is matched immediately instead of first checking the existence of it. 