### PR TITLE
Implements support for resolving images resolved by nested linked items, removes 'elements' property in favor of 'debug' property (breaking change)

### DIFF
--- a/packages/delivery/lib/interfaces/item/i-content-item-debug-data.interface.ts
+++ b/packages/delivery/lib/interfaces/item/i-content-item-debug-data.interface.ts
@@ -1,0 +1,5 @@
+import { ItemContracts } from '../../data-contracts/item-contracts';
+
+export interface IContentItemDebugData {
+    rawElements: ItemContracts.IContentItemElementsContracts;
+}

--- a/packages/delivery/lib/interfaces/item/icontent-item.interface.ts
+++ b/packages/delivery/lib/interfaces/item/icontent-item.interface.ts
@@ -1,4 +1,5 @@
 import { ItemLinkResolver, ItemPropertyResolver, ItemRichTextResolver } from '../../models/item/item-resolvers';
+import { IContentItemDebugData } from './i-content-item-debug-data.interface';
 import { IContentItemSystemAttributes } from './icontent-item-system-attributes.interface';
 
 export interface IContentItem {
@@ -14,9 +15,9 @@ export interface IContentItem {
     system: IContentItemSystemAttributes;
 
     /**
-     * Elements of the item
+     * Debug data of the item
      */
-    elements: any;
+    debug: IContentItemDebugData;
 
     /**
     * Function used to bind fields returned from Kentico Cloud to a model property.

--- a/packages/delivery/lib/interfaces/item/index.ts
+++ b/packages/delivery/lib/interfaces/item/index.ts
@@ -6,3 +6,4 @@ export * from './icontent-item.interface';
 export * from './icontent-item-system-attributes.interface';
 export * from './irich-text-resolver-result';
 export * from './i-type-resolver-data.interface';
+export * from './i-content-item-debug-data.interface';

--- a/packages/delivery/lib/mappers/field.mapper.ts
+++ b/packages/delivery/lib/mappers/field.mapper.ts
@@ -1,6 +1,6 @@
 import { enumHelper } from 'kentico-cloud-core';
 
-import { defaultCollissionResolver as defaultCollisionResolver, IDeliveryClientConfig } from '../config';
+import { defaultCollissionResolver, IDeliveryClientConfig } from '../config';
 import { ItemContracts } from '../data-contracts';
 import { FieldContracts, FieldDecorators, FieldModels, Fields, FieldType } from '../fields';
 import { IContentItem, IItemQueryConfig } from '../interfaces';
@@ -96,7 +96,7 @@ export class FieldMapper {
             const fieldMapping = this.resolveFieldMapping(itemInstance, elementCodename);
 
             if (fieldMapping.shouldMapField) {
-                itemInstance[fieldMapping.resolvedName] = this.mapField({
+                const mappedField = this.mapField({
                     fieldWrapper: {
                         field: field,
                         resolvedFieldName: fieldMapping.resolvedName
@@ -108,6 +108,9 @@ export class FieldMapper {
                     processedItems: data.processedItems,
                     queryConfig: data.queryConfig
                 });
+
+                // set mapped field to item instance
+                itemInstance[fieldMapping.resolvedName] = mappedField;
             }
         });
 
@@ -162,7 +165,7 @@ export class FieldMapper {
             }
 
             if (fieldType === FieldType.RichText) {
-                return this.mapRichTextField(data.fieldWrapper, data.modularContent, data.queryConfig, data.processedItems, data.processingStartedForCodenames, data.preparedItems);
+                return this.mapRichTextField(data.item, data.fieldWrapper, data.modularContent, data.queryConfig, data.processedItems, data.processingStartedForCodenames, data.preparedItems);
             }
 
             if (fieldType === FieldType.UrlSlug) {
@@ -182,6 +185,7 @@ export class FieldMapper {
     }
 
     private mapRichTextField(
+        item: IContentItem,
         fieldWrapper: IFieldMapWrapper,
         modularContent: ItemContracts.IModularContentWrapperContract,
         queryConfig: IItemQueryConfig,
@@ -256,7 +260,7 @@ export class FieldMapper {
             field.modular_content,
             {
                 links: links,
-                resolveHtml: () => richTextResolver.resolveHtml('', field.value, fieldWrapper.resolvedFieldName, {
+                resolveHtml: () => richTextResolver.resolveHtml(item.system.codename, field.value, fieldWrapper.resolvedFieldName, {
                     enableAdvancedLogging: this.config.enableAdvancedLogging ? this.config.enableAdvancedLogging : false,
                     images: images,
                     richTextHtmlParser: this.richTextHtmlParser,
@@ -563,7 +567,7 @@ export class FieldMapper {
     }
 
     private getCollisionResolver(): ItemFieldCollisionResolver {
-        return this.config.collisionResolver ? this.config.collisionResolver : defaultCollisionResolver;
+        return this.config.collisionResolver ? this.config.collisionResolver : defaultCollissionResolver;
     }
 
     private collidesWithAnotherField(fieldName: string, item: IContentItem): boolean {

--- a/packages/delivery/lib/models/item/content-item.class.ts
+++ b/packages/delivery/lib/models/item/content-item.class.ts
@@ -1,5 +1,4 @@
-import { ItemContracts } from '../../data-contracts/item-contracts';
-import { IContentItem } from '../../interfaces';
+import { IContentItem, IContentItemDebugData } from '../../interfaces';
 import { ContentItemSystemAttributes } from './content-item-system-attributes';
 import { ItemLinkResolver, ItemPropertyResolver, ItemRichTextResolver } from './item-resolvers';
 
@@ -11,14 +10,14 @@ export class ContentItem implements IContentItem {
     [key: string]: any;
 
     /**
+     * Debug data of the item
+     */
+    public debug!: IContentItemDebugData;
+
+    /**
      * Content item system elements
      */
     public system!: ContentItemSystemAttributes;
-
-    /**
-     * Raw elements of the item
-     */
-    public elements!: ItemContracts.IContentItemElementsContracts;
 
     /**
     * Function used to bind fields returned from Kentico Cloud to a model property.

--- a/packages/delivery/lib/parser/adapters/browser-rich-text.parser.ts
+++ b/packages/delivery/lib/parser/adapters/browser-rich-text.parser.ts
@@ -9,16 +9,18 @@ import {
     IRichTextHtmlParser,
     IRichTextReplacements,
     IRichTextResolverResult,
+    ResolverContext,
 } from '../parse-models';
 import { parserConfiguration } from '../parser-configuration';
 
+
 export class BrowserRichTextParser implements IRichTextHtmlParser {
 
-    resolveRichTextField(contentItemCodename: string, html: string, fieldName: string, replacement: IRichTextReplacements, config: IHtmlResolverConfig): IRichTextResolverResult {
+    resolveRichTextField(resolverContext: ResolverContext, contentItemCodename: string, html: string, fieldName: string, replacement: IRichTextReplacements, config: IHtmlResolverConfig): IRichTextResolverResult {
         const doc = this.createWrapperElement(html);
 
         // get all linked items
-        const result = this.processRichTextField(contentItemCodename, fieldName, doc.children, replacement, config, {
+        const result = this.processRichTextField(resolverContext, contentItemCodename, fieldName, doc.children, replacement, config, {
             links: [],
             linkedItems: [],
             images: []
@@ -39,7 +41,7 @@ export class BrowserRichTextParser implements IRichTextHtmlParser {
         return element;
     }
 
-    private processRichTextField(contentItemCodename: string, fieldName: string, htmlCollection: HTMLCollection, replacement: IRichTextReplacements, config: IHtmlResolverConfig, result: IFeaturedObjects): IFeaturedObjects {
+    private processRichTextField(resolverContext: ResolverContext, contentItemCodename: string, fieldName: string, htmlCollection: HTMLCollection, replacement: IRichTextReplacements, config: IHtmlResolverConfig, result: IFeaturedObjects): IFeaturedObjects {
         if (!htmlCollection || htmlCollection.length === 0) {
             // there are no more nodes
         } else {
@@ -85,7 +87,7 @@ export class BrowserRichTextParser implements IRichTextHtmlParser {
                         const linkedItemHtml = replacement.getLinkedItemHtml(linkItemContentObject.dataCodename, type);
 
                         // recursively run resolver on the HTML obtained by resolver
-                        newElem.innerHTML = this.resolveRichTextField(linkItemContentObject.dataCodename, linkedItemHtml, fieldName, replacement, config).resolvedHtml;
+                        newElem.innerHTML = this.resolveRichTextField('nested', linkItemContentObject.dataCodename, linkedItemHtml, fieldName, replacement, config).resolvedHtml;
 
                         // add classes
                         newElem.className = config.linkedItemWrapperClasses.map(m => m).join(' ');
@@ -165,7 +167,7 @@ export class BrowserRichTextParser implements IRichTextHtmlParser {
                         result.images.push(imageObj);
 
                         // get image result
-                        const imageResult = replacement.getImageResult(contentItemCodename, imageObj.imageId, fieldName);
+                        const imageResult = replacement.getImageResult(resolverContext, contentItemCodename, imageObj.imageId, fieldName);
 
                         // get src attribute of img tag
                         const srcAttribute = element.attributes.getNamedItem(parserConfiguration.imageElementData.srcAttribute);
@@ -181,7 +183,7 @@ export class BrowserRichTextParser implements IRichTextHtmlParser {
 
                 // recursively process child nodes
                 if (element.children && element.children.length > 0) {
-                    this.processRichTextField(contentItemCodename, fieldName, element.children, replacement, config, result);
+                    this.processRichTextField(resolverContext, contentItemCodename, fieldName, element.children, replacement, config, result);
                 }
             }
         }

--- a/packages/delivery/lib/parser/parse-models.ts
+++ b/packages/delivery/lib/parser/parse-models.ts
@@ -1,8 +1,10 @@
 import { RichTextContentType } from '../enums';
 import { IItemQueryConfig, ILinkResolverResult, IRichTextImageResolverResult } from '../interfaces';
 
+export type ResolverContext = 'root' | 'nested';
+
 export interface IRichTextHtmlParser {
-    resolveRichTextField(contentItemCodename: string, html: string, fieldName: string, replacement: IRichTextReplacements, config: IHtmlResolverConfig): IRichTextResolverResult;
+    resolveRichTextField(resolverContext: ResolverContext, contentItemCodename: string, html: string, fieldName: string, replacement: IRichTextReplacements, config: IHtmlResolverConfig): IRichTextResolverResult;
 }
 
 export interface IFeaturedObjects {
@@ -18,7 +20,7 @@ export interface IRichTextResolverResult extends IFeaturedObjects {
 export interface IRichTextReplacements {
     getLinkedItemHtml: (itemCodename: string, itemType: RichTextContentType) => string;
     getLinkResult: (itemId: string, linkText: string) => string | undefined | ILinkResolverResult;
-    getImageResult: (linkedItemCodename: string, imageId: string, fieldName: string) => IRichTextImageResolverResult;
+    getImageResult: (resolverCotnext: ResolverContext, linkedItemCodename: string, imageId: string, fieldName: string) => IRichTextImageResolverResult;
 }
 
 export interface IHtmlResolverConfig {

--- a/packages/delivery/lib/resolvers/delivery-item-strongly-type.resolver.ts
+++ b/packages/delivery/lib/resolvers/delivery-item-strongly-type.resolver.ts
@@ -81,7 +81,9 @@ export class DeliveryItemStronglyTypeResolver {
      */
     private assignDefaultProperties(item: IContentItem, rawItem: ItemContracts.IContentItemContract): void {
         item.system = this.mapSystemAttributes(rawItem[this.systemFieldName]);
-        item.elements = rawItem[this.elementsFieldName];
+        item.debug = {
+            rawElements: rawItem[this.elementsFieldName],
+        };
     }
 
 }

--- a/packages/delivery/lib/resolvers/url-slug.resolver.ts
+++ b/packages/delivery/lib/resolvers/url-slug.resolver.ts
@@ -1,12 +1,12 @@
-import { ILinkResolverResult } from '../interfaces';
-import { ContentItem, ItemLinkResolver, Link } from '../models';
+import { IContentItem, ILinkResolverResult } from '../interfaces';
+import { ItemLinkResolver, Link } from '../models';
 
 export class UrlSlugResolver {
   resolveUrl(data: {
     type: string;
     fieldValue: string;
     fieldName: string;
-    item: ContentItem;
+    item: IContentItem;
     linkResolver: ItemLinkResolver | undefined;
     enableAdvancedLogging: boolean;
   }): string | ILinkResolverResult | undefined {

--- a/packages/delivery/test-browser/isolated-tests/fields/rich-text-images.spec.ts
+++ b/packages/delivery/test-browser/isolated-tests/fields/rich-text-images.spec.ts
@@ -1,18 +1,26 @@
 import {
+    ContentItem,
+    ContentItemSystemAttributes,
     Fields,
     getParserAdapter,
-    IDeliveryClientConfig,
     ImageUrlBuilder,
     RichTextImage,
     richTextResolver,
-    TypeResolver,
 } from '../../../lib';
 
 describe('RichTextField with Images', () => {
-    const config: IDeliveryClientConfig = {
-        projectId: 'xxx',
-        typeResolvers: []
-    };
+    const linkedItemCodename = 'xLinkedItemCodename';
+
+    const linkedItem = new ContentItem();
+    linkedItem.system = new ContentItemSystemAttributes({
+        codename: linkedItemCodename,
+        id: 'x',
+        language: 'en',
+        lastModified: new Date(),
+        name: 'x linked item',
+        sitemapLocations: [],
+        type: 'article'
+    });
 
     // prepare images
     const images: RichTextImage[] = [
@@ -33,6 +41,13 @@ describe('RichTextField with Images', () => {
         })
     ];
 
+    // set images to rich text
+    linkedItem['name'] = new Fields.RichTextField('name', '', [], {
+        images: images,
+        links: [],
+        resolveHtml: () => ''
+    });
+
     const image1 = images[0];
     const image2 = images[1];
 
@@ -45,10 +60,10 @@ describe('RichTextField with Images', () => {
     it(`Checks that images are resolved using default resolver`, () => {
         const field = new Fields.RichTextField('name', html, [], {
             links: [],
-            resolveHtml: () => richTextResolver.resolveHtml('', html, 'name', {
+            resolveHtml: () => richTextResolver.resolveHtml(linkedItemCodename, html, 'name', {
                 enableAdvancedLogging: false,
                 links: [],
-                getLinkedItem: (codename) => undefined,
+                getLinkedItem: (codename) => linkedItem,
                 images: images,
                 richTextHtmlParser: getParserAdapter(),
                 linkedItemWrapperClasses: [],
@@ -72,10 +87,10 @@ describe('RichTextField with Images', () => {
     it(`Checks that images are resolved using custom resolver`, () => {
         const field2 = new Fields.RichTextField('name', html, [], {
             links: [],
-            resolveHtml: () => richTextResolver.resolveHtml('', html, 'name', {
+            resolveHtml: () => richTextResolver.resolveHtml(linkedItemCodename, html, 'name', {
                 enableAdvancedLogging: false,
                 links: [],
-                getLinkedItem: (codename) => undefined,
+                getLinkedItem: (codename) => linkedItem,
                 images: images,
                 richTextHtmlParser: getParserAdapter(),
                 linkedItemWrapperClasses: [],

--- a/packages/delivery/test-browser/isolated-tests/resolvers/item-resolver-resolver.spec.ts
+++ b/packages/delivery/test-browser/isolated-tests/resolvers/item-resolver-resolver.spec.ts
@@ -117,7 +117,7 @@ describe('Item resolver', () => {
 
         for (const star of response.item.stars) {
 
-            expect(star.elements).toBeDefined();
+            expect(star.debug.rawElements).toBeDefined();
             expect(star.system).toEqual(jasmine.any(ContentItemSystemAttributes));
 
             expect(star).toEqual(jasmine.any(Actor));

--- a/packages/delivery/test-browser/live-tests/item/live-item.spec.ts
+++ b/packages/delivery/test-browser/live-tests/item/live-item.spec.ts
@@ -138,9 +138,11 @@ describe('Live item', () => {
     expect(response.item.plot.getHtml()).toContain(expectedHtml);
   });
 
-  it(`elements property should be set`, () => {
-    expect(response.item.elements).toBeDefined();
-    expect(response.item.elements.title.value).toEqual(response.item.title.text);
+  it(`debug property should be defiend and filled with debug data`, () => {
+    expect(response.item.debug).toBeDefined();
+    expect(response.item.debug.rawElements).toBeDefined();
+
+    expect(response.item.debug.rawElements.title.value).toEqual(response.item.title.text);
   });
 
   it(`images should be mapped in plot rich text field`, () => {

--- a/packages/delivery/test-browser/live-tests/items/live-items.spec.ts
+++ b/packages/delivery/test-browser/live-tests/items/live-items.spec.ts
@@ -46,10 +46,10 @@ describe('Live items', () => {
     expect(response.lastItem.system.codename).toEqual(response.items[response.items.length - 1].system.codename);
   });
 
-  it(`elements property should be set for all items`, () => {
+  it(`debug property should be set for all items`, () => {
     response.items.forEach(item => {
-      expect(item.elements).toBeDefined();
-      expect(item.elements.title.value).toEqual(item.title.text);
+      expect(item.debug).toBeDefined();
+      expect(item.debug.rawElements).toBeDefined();
     });
   });
 

--- a/packages/delivery/test-browser/new-tests-refactoring/fields/collission-field-names.spec.json
+++ b/packages/delivery/test-browser/new-tests-refactoring/fields/collission-field-names.spec.json
@@ -17,9 +17,9 @@
           "name": "System",
           "value": "im system"
         },
-        "elements": {
+        "debug": {
           "type": "text",
-          "name": "Elements",
+          "name": "debug",
           "value": "hello"
         },
         "title": {

--- a/packages/delivery/test-browser/new-tests-refactoring/fields/collission-field-names.spec.ts
+++ b/packages/delivery/test-browser/new-tests-refactoring/fields/collission-field-names.spec.ts
@@ -2,7 +2,7 @@ import { ContentItem, ContentItemSystemAttributes, Fields } from '../../../lib';
 import { getDeliveryClientWithJson } from '../setup';
 import * as responseJson from './collission-field-names.spec.json';
 
-describe(`Collision field names ('system' & 'elements')`, () => {
+describe(`Collision field names ('system' & 'debug')`, () => {
     let item: ContentItem;
 
     beforeAll((done) => {
@@ -14,17 +14,14 @@ describe(`Collision field names ('system' & 'elements')`, () => {
             });
     });
 
-    it(`Field with codename 'elements' should be remapped`, () => {
-        expect(responseJson.item.elements.elements).toBeDefined();
-        const newElementsField = item['_elements'] as Fields.TextField;
+    it(`Field with codename 'debug' should be remapped`, () => {
+        const newElementsField = item['_debug'] as Fields.TextField;
 
-        expect(newElementsField).toBeDefined();
         expect(newElementsField).toEqual(jasmine.any(Fields.TextField));
-        expect(newElementsField.value).toEqual(responseJson.item.elements.elements.value);
+        expect(newElementsField.value).toEqual(responseJson.item.elements.debug.value);
 
         // original elements should still be mapped
-        expect(item.elements).toBeDefined();
-        expect(responseJson.item.elements.title.value).toEqual(item.elements.title.value);
+        expect(responseJson.item.elements.title.value).toEqual(item.title.value);
     });
 
     it(`Field with codename 'system' should be remapped`, () => {
@@ -32,12 +29,10 @@ describe(`Collision field names ('system' & 'elements')`, () => {
 
         const systemField = item['_system'] as Fields.TextField;
 
-        expect(systemField).toBeDefined();
         expect(systemField).toEqual(jasmine.any(Fields.TextField));
         expect(systemField.value).toEqual(responseJson.item.elements.system.value);
 
         // original system attributes should still be mapped
-        expect(item.system).toBeDefined();
         expect(item.system).toEqual(jasmine.any(ContentItemSystemAttributes));
     });
 


### PR DESCRIPTION
Resolving images in nested linked items using rich text resolver is quite complex. The main issue is there is no element context for these images. We only have the root element on which `getHtml` was called and therefore for nested elements we have to find all RichText elements on content item and find proper image based on the `imageId`. This is clearly not the most efficient way. 

Additionally, `elements` property defined on each `IContentItem` was renamed to `debug` and actual data placed under `rawElements` property. There will be further debug information added in future.