### PR TITLE
Fixes content type model names, refactors delivery client configuration (separates preview, secure & proxy into own sub categories)

### DIFF
--- a/packages/delivery/lib/client/delivery-client.ts
+++ b/packages/delivery/lib/client/delivery-client.ts
@@ -29,11 +29,10 @@ export class DeliveryClient implements IDeliveryClient {
    */
   constructor(protected config: IDeliveryClientConfig) {
     if (!config) {
-      throw Error(`Please provide client configuration`);
+      throw Error(`Delivery client configuration is not set`);
     }
 
     this.mappingService = new MappingService(config, getParserAdapter());
-
     this.queryService = new QueryService(
       config,
       config.httpService ? config.httpService : new HttpService({

--- a/packages/delivery/lib/config/delivery-client.config.ts
+++ b/packages/delivery/lib/config/delivery-client.config.ts
@@ -3,6 +3,49 @@ import { IHeader, IHttpRequestConfig, IHttpRequestResponse, IHttpService } from 
 import { ElementResolver } from '../elements';
 import { ElementCollisionResolver, IProxyUrlData, IQueryConfig, TypeResolver } from '../models';
 
+export interface IDeliveryClientPreviewConfig {
+    /**
+     * Indicates if preview mode should be enabled globally
+     */
+    isEnabledGlobally: boolean;
+    /**
+    * Preview API key
+    */
+    previewApiKey: string;
+}
+
+export interface IDeliveryClientSecureConfig {
+    /**
+    * Indicates if secure mode should be enabled globally
+    */
+    isEnabledGlobally: boolean;
+    /**
+    * Secure API key
+    * Important: Use secured API only when running on Node.JS server, otherwise
+    * your key will be visible in browsers when making requests.
+    */
+    secureApiKey: string;
+}
+
+export interface IDeliveryClientProxyConfig {
+    /**
+     * Base url used for preview reqeusts. Defaults to 'preview-deliver.kenticocloud.com'
+     */
+    basePreviewUrl?: string;
+
+    /**
+     * Can be used to generate custom request urls.
+     * Useful when you have a proxy server and need to transform url to a specific format
+     * and setting 'baseUrl' is not sufficient.
+     */
+    advancedProxyUrlResolver?: (data: IProxyUrlData) => string;
+
+    /**
+    * Base url used for all requests. Defaults to 'deliver.kenticocloud.com'
+    */
+    baseUrl?: string;
+}
+
 export interface IDeliveryClientConfig {
 
     /**
@@ -11,65 +54,46 @@ export interface IDeliveryClientConfig {
     projectId: string;
 
     /**
-     * Array of resolvers that are used to create instances of registered classes automatically.
-     * If not set, items will be instances of 'ContentItem' class
+     * Type resolver is used to create an instance of class based on content item's type. For example,
+     * if content item has 'article' content type (system.type), you can map it to 'Article' class with
+     * properties, methods and global content item configuration. 
+     * If not set, content item will use default 'ContentItem' class
      */
     typeResolvers?: TypeResolver[];
 
     /**
-     * Use to resolve elements to custom models (e.g. custom elements)
+     * Resolver used for using custom models for custom elements.
      */
     elementResolver?: ElementResolver;
 
     /**
-    * Indicates if advanced (developer's) issues are logged in console. Enable for development and disable in production
+    * When enabled, additional information are logged in console for certain issues.
+    * Disable in production environments.
     */
-    enableAdvancedLogging?: boolean;
+    isDeveloperMode?: boolean;
 
     /**
-    * Preview API key used to get unpublished content items
-    */
-    previewApiKey?: string;
+     * Preview mode configuration
+     */
+    previewMode?: IDeliveryClientPreviewConfig;
 
     /**
-    * Secured API key.
-    * !! Important !!
-    * Use secured API only when running on Node.JS server, otherwise you are exposing your key to all clients
-    */
-    securedApiKey?: string;
+     * Secure mode configuration
+     */
+    secureMode?: IDeliveryClientSecureConfig;
 
     /**
-    * Indicates if preview mode is enabled globally
-    */
-    enablePreviewMode?: boolean;
+     * Proxy configuration
+     */
+    proxy?: IDeliveryClientProxyConfig;
 
     /**
-   * Indicates if secured mode is enabled globally
-   */
-    enableSecuredMode?: boolean;
-
-    /**
-     * Default content language, can be overidden with languageParameter method
+     * Default language of content items
      */
     defaultLanguage?: string;
 
     /**
-     * Base url used for all requests. Defaults to 'deliver.kenticocloud.com'
-     */
-    baseUrl?: string;
-
-    /**
-     * Can be used to generate custom request urls. Useful when you have a proxy server and need to transform url to a specific format
-     */
-    proxyUrl?: (data: IProxyUrlData) => string;
-
-    /**
-     * Base url used for preview reqeusts. Defaults to 'preview-deliver.kenticocloud.com'
-     */
-    basePreviewUrl?: string;
-
-    /**
-     * Number of retry attempts when error occures. When not set, default number of attempts (3) are used. To disable set to 0.
+     * Number of retry attempts for failed requests. Defaults to 3. To disable retries set use 0.
      */
     retryAttempts?: number;
 
@@ -101,17 +125,17 @@ export interface IDeliveryClientConfig {
     };
 
     /**
-     * Adds ability to add extra headers to each http request
+     * Extra headers added to each http request
      */
     globalHeaders?: (queryConfig: IQueryConfig) => IHeader[];
 
     /**
-     * Resolver called when there are multiple elements with the same name in content item (example collision element names include 'system' or 'elements')
+     * Resolver used when content item properties would overlap. Collision resolver can be used to change property name to avoid conflicts.
      */
     collisionResolver?: ElementCollisionResolver;
 
     /**
-     * Array of status codes that should be retried when request fails. Defaults to requests with '500' status code.
+     * Array of status codes that should be retried when request fails. Defaults [500].
      */
     retryStatusCodes?: number[];
 

--- a/packages/delivery/lib/data-contracts/type-contracts.ts
+++ b/packages/delivery/lib/data-contracts/type-contracts.ts
@@ -15,11 +15,11 @@ export namespace TypeContracts {
         elements: IElementContract;
     }
 
-    export interface IViewContentTypeContract {
+    export interface IListContentTypeContract {
         types: IContentTypeContract[];
         pagination: IPaginationContract;
     }
 
-    export interface IListContentTypesContract extends IContentTypeContract {
+    export interface IViewContentTypeContract extends IContentTypeContract {
     }
 }

--- a/packages/delivery/lib/mappers/element.mapper.ts
+++ b/packages/delivery/lib/mappers/element.mapper.ts
@@ -249,7 +249,7 @@ export class ElementMapper {
             {
                 links: links,
                 resolveHtmlFunc: () => richTextResolver.resolveHtml(item.system.codename, rawElement.value, elementWrapper.propertyName, {
-                    enableAdvancedLogging: this.config.enableAdvancedLogging ? this.config.enableAdvancedLogging : false,
+                    enableAdvancedLogging: this.config.isDeveloperMode ? this.config.isDeveloperMode : false,
                     images: images,
                     richTextHtmlParser: this.richTextHtmlParser,
                     getLinkedItem: (codename) => this.getOrSaveLinkedItemForElement(codename, rawElement, queryConfig, modularContent, processedItems, processingStartedForCodenames, preparedItems),
@@ -312,7 +312,7 @@ export class ElementMapper {
                     elementName: elementWrapper.propertyName,
                     elementValue: elementWrapper.rawElement.value,
                     item: item,
-                    enableAdvancedLogging: this.config.enableAdvancedLogging ? this.config.enableAdvancedLogging : false,
+                    enableAdvancedLogging: this.config.isDeveloperMode ? this.config.isDeveloperMode : false,
                     linkResolver: linkResolver
                 })
             });
@@ -328,14 +328,14 @@ export class ElementMapper {
     }
     ): ContentItem[] {
         if (!data.elementWrapper) {
-            if (this.config.enableAdvancedLogging) {
+            if (this.config.isDeveloperMode) {
                 console.warn(`Cannot map linked item element because element does not exist. This warning can be turned off by disabling 'enableAdvancedLogging' option.`);
             }
             return [];
         }
 
         if (!data.elementWrapper.rawElement.value) {
-            if (this.config.enableAdvancedLogging) {
+            if (this.config.isDeveloperMode) {
                 console.warn(`Cannot map linked item of '${data.elementWrapper.rawElement.name}' because its value does not exist. This warning can be turned off by disabling 'enableAdvancedLogging' option.`);
             }
             return [];
@@ -353,7 +353,7 @@ export class ElementMapper {
                 result.push(linkedItem);
             } else {
                 // item was not found
-                if (this.config.enableAdvancedLogging) {
+                if (this.config.isDeveloperMode) {
                     // tslint:disable-next-line:max-line-length
                     console.warn(`Linked item with codename '${codename}' in linked items element '${data.elementWrapper.rawElement.name}' of '${data.elementWrapper.rawElement.type}' type could not be found. If you require this item, consider increasing 'depth' of your query. This warning can be turned off by disabling 'enableAdvancedLogging' option.`);
                 }

--- a/packages/delivery/lib/mappers/type.mapper.ts
+++ b/packages/delivery/lib/mappers/type.mapper.ts
@@ -3,11 +3,11 @@ import { ContentType, ContentTypeSystemAttributes, GenericElement, GenericElemen
 
 export class TypeMapper {
 
-    mapSingleType(response: TypeContracts.IListContentTypesContract): ContentType {
+    mapSingleType(response: TypeContracts.IViewContentTypeContract): ContentType {
         return this.mapType(response);
     }
 
-    mapMultipleTypes(response: TypeContracts.IViewContentTypeContract): ContentType[] {
+    mapMultipleTypes(response: TypeContracts.IListContentTypeContract): ContentType[] {
         const that = this;
         return response.types.map(function (type) {
             return that.mapType(type);

--- a/packages/delivery/lib/models/content-type/responses.ts
+++ b/packages/delivery/lib/models/content-type/responses.ts
@@ -4,7 +4,7 @@ import { ContentType } from './content-type-models';
 
 export namespace TypeResponses {
 
-    export class ViewContentTypeResponse implements ICloudResponse {
+    export class ListContentTypesResponse implements ICloudResponse {
 
         /**
         * Response containing multiple types
@@ -19,7 +19,7 @@ export namespace TypeResponses {
         ) { }
     }
 
-    export class ListContentTypesResponse implements ICloudResponse {
+    export class ViewContentTypeResponse implements ICloudResponse {
 
         /**
         * Response containing single type

--- a/packages/delivery/lib/query/type/base-type-query.class.ts
+++ b/packages/delivery/lib/query/type/base-type-query.class.ts
@@ -48,7 +48,7 @@ export abstract class BaseTypeQuery<
   }
 
   protected runMultipleTypesQuery(): Observable<
-    TypeResponses.ViewContentTypeResponse
+    TypeResponses.ListContentTypesResponse
   > {
     return this.queryService.getMultipleTypes(
       this.getMultipleTypesQueryUrl(),
@@ -58,7 +58,7 @@ export abstract class BaseTypeQuery<
 
   protected runSingleTypeQuery(
     codename: string
-  ): Observable<TypeResponses.ListContentTypesResponse> {
+  ): Observable<TypeResponses.ViewContentTypeResponse> {
     return this.queryService.getSingleType(
       this.getSingleTypeQueryUrl(codename),
       this._queryConfig

--- a/packages/delivery/lib/query/type/multiple-type-query.class.ts
+++ b/packages/delivery/lib/query/type/multiple-type-query.class.ts
@@ -5,7 +5,7 @@ import { Parameters, TypeResponses } from '../../models';
 import { QueryService } from '../../services';
 import { BaseTypeQuery } from './base-type-query.class';
 
-export class MultipleTypeQuery extends BaseTypeQuery<TypeResponses.ViewContentTypeResponse> {
+export class MultipleTypeQuery extends BaseTypeQuery<TypeResponses.ListContentTypesResponse> {
 
     constructor(
         protected config: IDeliveryClientConfig,
@@ -35,7 +35,7 @@ export class MultipleTypeQuery extends BaseTypeQuery<TypeResponses.ViewContentTy
     /**
     * Gets the runnable Observable
     */
-    toObservable(): Observable<TypeResponses.ViewContentTypeResponse> {
+    toObservable(): Observable<TypeResponses.ListContentTypesResponse> {
         return super.runMultipleTypesQuery();
     }
 

--- a/packages/delivery/lib/query/type/single-type-query.class.ts
+++ b/packages/delivery/lib/query/type/single-type-query.class.ts
@@ -5,7 +5,7 @@ import { TypeResponses } from '../../models';
 import { QueryService } from '../../services';
 import { BaseTypeQuery } from './base-type-query.class';
 
-export class SingleTypeQuery extends BaseTypeQuery<TypeResponses.ListContentTypesResponse> {
+export class SingleTypeQuery extends BaseTypeQuery<TypeResponses.ViewContentTypeResponse> {
 
     constructor(
         protected config: IDeliveryClientConfig,
@@ -22,7 +22,7 @@ export class SingleTypeQuery extends BaseTypeQuery<TypeResponses.ListContentType
     /**
     * Gets the runnable Observable
     */
-    toObservable(): Observable<TypeResponses.ListContentTypesResponse> {
+    toObservable(): Observable<TypeResponses.ViewContentTypeResponse> {
         return super.runSingleTypeQuery(this.typeCodename);
     }
 

--- a/packages/delivery/lib/services/delivery-query.service.ts
+++ b/packages/delivery/lib/services/delivery-query.service.ts
@@ -75,10 +75,10 @@ export class QueryService extends BaseDeliveryQueryService {
   getSingleType(
     url: string,
     queryConfig: IContentTypeQueryConfig
-  ): Observable<TypeResponses.ListContentTypesResponse> {
-    return this.getResponse<TypeContracts.IListContentTypesContract>(url, queryConfig).pipe(
+  ): Observable<TypeResponses.ViewContentTypeResponse> {
+    return this.getResponse<TypeContracts.IViewContentTypeContract>(url, queryConfig).pipe(
       map(response => {
-        return this.mappingService.listContentTypesResponse(response);
+        return this.mappingService.viewContentTypeResponse(response);
       })
     );
   }
@@ -91,10 +91,10 @@ export class QueryService extends BaseDeliveryQueryService {
   getMultipleTypes(
     url: string,
     queryConfig: IContentTypeQueryConfig
-  ): Observable<TypeResponses.ViewContentTypeResponse> {
-    return this.getResponse<TypeContracts.IViewContentTypeContract>(url, queryConfig).pipe(
+  ): Observable<TypeResponses.ListContentTypesResponse> {
+    return this.getResponse<TypeContracts.IListContentTypeContract>(url, queryConfig).pipe(
       map(response => {
-        return this.mappingService.viewContentTypeResponse(response);
+        return this.mappingService.listContentTypesResponse(response);
       })
     );
   }

--- a/packages/delivery/lib/services/mapping.service.ts
+++ b/packages/delivery/lib/services/mapping.service.ts
@@ -17,7 +17,7 @@ import { IRichTextHtmlParser } from '../parser';
 
 export interface IMappingService {
     listContentTypesResponse(
-        response: IBaseResponse<TypeContracts.IListContentTypesContract>
+        response: IBaseResponse<TypeContracts.IListContentTypeContract>
     ): TypeResponses.ListContentTypesResponse;
 
     viewContentTypeResponse(
@@ -70,14 +70,23 @@ export class MappingService implements IMappingService {
      * @param response Response data
      */
     listContentTypesResponse(
-        response: IBaseResponse<TypeContracts.IListContentTypesContract>
+        response: IBaseResponse<TypeContracts.IListContentTypeContract>
     ): TypeResponses.ListContentTypesResponse {
 
-        // map type
-        const type = this.typeMapper.mapSingleType(response.data);
+        // map types
+        const types = this.typeMapper.mapMultipleTypes(response.data);
+
+        // pagination
+        const pagination: Pagination = new Pagination({
+            skip: response.data.pagination.skip,
+            count: response.data.pagination.count,
+            limit: response.data.pagination.limit,
+            nextPage: response.data.pagination.next_page
+        });
 
         return new TypeResponses.ListContentTypesResponse(
-            type,
+            types,
+            pagination,
             this.mapResponseDebug(response)
         );
     }
@@ -91,20 +100,11 @@ export class MappingService implements IMappingService {
         response: IBaseResponse<TypeContracts.IViewContentTypeContract>
     ): TypeResponses.ViewContentTypeResponse {
 
-        // map types
-        const types = this.typeMapper.mapMultipleTypes(response.data);
-
-        // pagination
-        const pagination: Pagination = new Pagination({
-            skip: response.data.pagination.skip,
-            count: response.data.pagination.count,
-            limit: response.data.pagination.limit,
-            nextPage: response.data.pagination.next_page
-        });
+        // map type
+        const type = this.typeMapper.mapSingleType(response.data);
 
         return new TypeResponses.ViewContentTypeResponse(
-            types,
-            pagination,
+            type,
             this.mapResponseDebug(response)
         );
     }

--- a/packages/delivery/test-browser/isolated-tests/core/proxy-url-spec.ts
+++ b/packages/delivery/test-browser/isolated-tests/core/proxy-url-spec.ts
@@ -6,9 +6,11 @@ describe('Proxy URL #1', () => {
 
   const client = new DeliveryClient({
     projectId: 'xxx',
-    proxyUrl: (data) => {
-      proxyData = data;
-      return 'http://custom-proxy.io';
+    proxy: {
+      advancedProxyUrlResolver: (data) => {
+        proxyData = data;
+        return 'http://custom-proxy.io';
+      }
     }
   });
 

--- a/packages/delivery/test-browser/isolated-tests/resolvers/item-resolver-resolver.spec.ts
+++ b/packages/delivery/test-browser/isolated-tests/resolvers/item-resolver-resolver.spec.ts
@@ -29,7 +29,7 @@ function getQueryService(advancedLogging: boolean = false): MockQueryService {
     setup(context);
 
     const config = context.getConfig();
-    config.enableAdvancedLogging = advancedLogging;
+    config.isDeveloperMode = advancedLogging;
 
     return new MockQueryService(config, new HttpService(), {
         host: sdkInfo.host,

--- a/packages/delivery/test-browser/isolated-tests/resolvers/type-resolver-data.spec.ts
+++ b/packages/delivery/test-browser/isolated-tests/resolvers/type-resolver-data.spec.ts
@@ -22,7 +22,7 @@ function getQueryService(advancedLogging: boolean = false): MockQueryService {
     setup(context);
 
     const config = context.getConfig();
-    config.enableAdvancedLogging = advancedLogging;
+    config.isDeveloperMode = advancedLogging;
 
     return new MockQueryService(config, new HttpService(), {
         host: sdkInfo.host,

--- a/packages/delivery/test-browser/live-tests/types/live-type.spec.ts
+++ b/packages/delivery/test-browser/live-tests/types/live-type.spec.ts
@@ -7,7 +7,7 @@ describe('Live type', () => {
   setup(context);
 
   const codename: string = 'movie';
-  let response: TypeResponses.ListContentTypesResponse;
+  let response: TypeResponses.ViewContentTypeResponse;
 
   const multipleChoiceElement: string = 'category';
   const taxonomyElement: string = 'releasecategory';
@@ -16,7 +16,7 @@ describe('Live type', () => {
     context.deliveryClient.type(codename)
       .toObservable()
       .subscribe(r => {
-        response = r as TypeResponses.ListContentTypesResponse;
+        response = r;
         done();
       });
   });

--- a/packages/delivery/test-browser/live-tests/types/live-types.spec.ts
+++ b/packages/delivery/test-browser/live-tests/types/live-types.spec.ts
@@ -6,13 +6,13 @@ describe('Live types', () => {
   const context = new Context();
   setup(context);
 
-  let response: TypeResponses.ViewContentTypeResponse;
+  let response: TypeResponses.ListContentTypesResponse;
 
   beforeAll((done) => {
     context.deliveryClient.types()
       .toObservable()
       .subscribe(r => {
-        response = r as TypeResponses.ViewContentTypeResponse;
+        response = r as TypeResponses.ListContentTypesResponse;
         done();
       });
   });

--- a/packages/delivery/test-browser/official/official-kentico-cloud-examples.ts
+++ b/packages/delivery/test-browser/official/official-kentico-cloud-examples.ts
@@ -33,8 +33,8 @@ describe('Official Kentico cloud examples (used in API reference https://develop
     /* ------------- Prepare responses ----------- */
     let itemResponse: ItemResponses.ViewContentItemResponse<Article>;
     let itemsResponse: ItemResponses.ListContentItemsResponse<Article>;
-    let typeResponse: TypeResponses.ListContentTypesResponse;
-    let typesResponse: TypeResponses.ViewContentTypeResponse;
+    let typeResponse: TypeResponses.ViewContentTypeResponse;
+    let typesResponse: TypeResponses.ListContentTypesResponse;
     let taxonomyResponse: TaxonomyResponses.ViewTaxonomyGroupResponse;
     let taxonomiesReponse: TaxonomyResponses.ListTaxonomyGroupsResponse;
     let elementResponse: ElementResponses.ViewContentTypeElementResponse;

--- a/packages/delivery/test-browser/setup/context.ts
+++ b/packages/delivery/test-browser/setup/context.ts
@@ -5,6 +5,8 @@ import { IHeader } from 'kentico-cloud-core';
 
 export class Context {
 
+  public deliveryClient!: DeliveryClient;
+
   /**
    * Use browser version of html parser when running tests in browser
    */
@@ -14,7 +16,6 @@ export class Context {
   public projectId!: string;
   public previewApiKey?: string;
   public securedApiKey?: string;
-  public deliveryClient!: DeliveryClient;
   public usePreviewMode: boolean = false;
   public useSecuredMode: boolean = false;
   public defaultLanguage?: string;
@@ -52,14 +53,20 @@ export class Context {
     return {
       projectId: this.projectId,
       typeResolvers: this.typeResolvers,
-      enableAdvancedLogging: this.enableAdvancedLogging,
-      enablePreviewMode: this.usePreviewMode,
-      previewApiKey: this.previewApiKey,
+      isDeveloperMode: this.enableAdvancedLogging,
+      previewMode: {
+        isEnabledGlobally: this.usePreviewMode,
+        previewApiKey: this.previewApiKey || ''
+      },
+      secureMode: {
+        isEnabledGlobally: this.useSecuredMode,
+        secureApiKey: this.securedApiKey || ''
+      },
+      proxy: {
+        baseUrl: this.baseUrl,
+        basePreviewUrl: this.basePreviewUrl
+      },
       defaultLanguage: this.defaultLanguage,
-      baseUrl: this.baseUrl,
-      basePreviewUrl: this.basePreviewUrl,
-      enableSecuredMode: this.useSecuredMode,
-      securedApiKey: this.securedApiKey,
       retryAttempts: this.retryAttempts,
       globalHeaders: this.globalHeaders,
       retryStatusCodes: this.retryStatusCodes

--- a/packages/delivery/test-browser/setup/models.ts
+++ b/packages/delivery/test-browser/setup/models.ts
@@ -76,8 +76,8 @@ export class AllTestObjects {
   public taxonomies!: TaxonomyResponses.ListTaxonomyGroupsResponse;
 
   // types
-  public type!: TypeResponses.ListContentTypesResponse;
-  public types!: TypeResponses.ViewContentTypeResponse;
+  public type!: TypeResponses.ViewContentTypeResponse;
+  public types!: TypeResponses.ListContentTypesResponse;
 
   // elements
   public element!: ElementResponses.ViewContentTypeElementResponse;
@@ -92,8 +92,8 @@ export class AllTestObjects {
     taxonomies: TaxonomyResponses.ListTaxonomyGroupsResponse,
 
     // types
-    type: TypeResponses.ListContentTypesResponse,
-    types: TypeResponses.ViewContentTypeResponse,
+    type: TypeResponses.ViewContentTypeResponse,
+    types: TypeResponses.ListContentTypesResponse,
 
     // elements
     element: ElementResponses.ViewContentTypeElementResponse

--- a/packages/delivery/test-browser/setup/setup.ts
+++ b/packages/delivery/test-browser/setup/setup.ts
@@ -44,15 +44,21 @@ export function setup(context: Context) {
     const deliveryClientConfig: IDeliveryClientConfig = {
         projectId: projectId,
         typeResolvers: typeResolvers,
-        previewApiKey: previewApiKey,
-        enablePreviewMode: context.usePreviewMode,
+        previewMode: {
+            isEnabledGlobally: context.usePreviewMode,
+            previewApiKey: previewApiKey || ''
+        },
+        secureMode: {
+            isEnabledGlobally: context.useSecuredMode,
+            secureApiKey: securedApiKey || ''
+        },
         defaultLanguage: context.defaultLanguage,
-        baseUrl: context.baseUrl,
-        basePreviewUrl: context.basePreviewUrl,
-        securedApiKey: securedApiKey,
-        enableSecuredMode: context.useSecuredMode,
+        proxy: {
+            baseUrl: context.baseUrl,
+            basePreviewUrl: context.basePreviewUrl,
+        },
         retryAttempts: context.retryAttempts,
-        enableAdvancedLogging: context.enableAdvancedLogging,
+        isDeveloperMode: context.enableAdvancedLogging,
         globalHeaders: context.globalHeaders,
         retryStatusCodes: context.retryStatusCodes,
         httpInterceptors: {

--- a/packages/delivery/test-node/official/list-content-items.js
+++ b/packages/delivery/test-node/official/list-content-items.js
@@ -33,7 +33,7 @@ describe('#List content items', () => {
 
     it('Response should be of proper type', () => {
         assert.ok(result);
-        assert.ok((result instanceof KenticoCloud.ItemResponses.DeliveryItemListingResponse));
+        assert.ok((result instanceof KenticoCloud.ItemResponses.ListContentItemsResponse));
     });
 
     it('Response should have > 0 && < 4 items', () => {

--- a/packages/delivery/test-node/official/list-content-types.js
+++ b/packages/delivery/test-node/official/list-content-types.js
@@ -21,7 +21,7 @@ describe('#List content types', () => {
 
     it('Response should be of proper type', () => {
         assert.ok(result);
-        assert.ok((result instanceof KenticoCloud.TypeResponses.DeliveryTypeListingResponse));
+        assert.ok((result instanceof KenticoCloud.TypeResponses.ListContentTypesResponse));
     });
 
     it('Response items should be of proper type', () => {

--- a/packages/delivery/test-node/official/list-taxonomy-groups.js
+++ b/packages/delivery/test-node/official/list-taxonomy-groups.js
@@ -22,7 +22,7 @@ describe('#List taxonomy groups', () => {
 
     it('Response should be of proper type', () => {
         assert.ok(result);
-        assert.ok((result instanceof KenticoCloud.TaxonomyResponses.TaxonomiesResponse));
+        assert.ok((result instanceof KenticoCloud.TaxonomyResponses.ListTaxonomyGroupsResponse));
     });
 
     it('Response items should be of proper type', () => {

--- a/packages/delivery/test-node/official/view-content-item.js
+++ b/packages/delivery/test-node/official/view-content-item.js
@@ -31,7 +31,7 @@ describe('#View content item', () => {
 
     it('Response should be of proper type', () => {
         assert.ok(result);
-        assert.ok((result instanceof KenticoCloud.ItemResponses.DeliveryItemResponse));
+        assert.ok((result instanceof KenticoCloud.ItemResponses.ViewContentItemResponse));
     });
 
     it('Response items should be of proper type', () => {

--- a/packages/delivery/test-node/official/view-content-type-element.js
+++ b/packages/delivery/test-node/official/view-content-type-element.js
@@ -20,7 +20,7 @@ describe('#View content type element', () => {
 
     it('Response should be of proper type', () => {
         assert.ok(result);
-        assert.ok((result instanceof KenticoCloud.ElementResponses.ElementResponse));
+        assert.ok((result instanceof KenticoCloud.ElementResponses.ViewContentTypeElementResponse));
     });
 
     it('Response item should be of proper type', () => {

--- a/packages/delivery/test-node/official/view-content-type.js
+++ b/packages/delivery/test-node/official/view-content-type.js
@@ -20,7 +20,7 @@ describe('#View content type', () => {
 
     it('Response should be of proper type', () => {
         assert.ok(result);
-        assert.ok((result instanceof KenticoCloud.TypeResponses.DeliveryTypeResponse));
+        assert.ok((result instanceof KenticoCloud.TypeResponses.ViewContentTypeResponse));
     });
 
     it('Response items should be of proper type', () => {

--- a/packages/delivery/test-node/official/view-taxonomy-group.js
+++ b/packages/delivery/test-node/official/view-taxonomy-group.js
@@ -20,7 +20,7 @@ describe('#View taxonomy group', () => {
 
     it('Response should be of proper type', () => {
         assert.ok(result);
-        assert.ok((result instanceof KenticoCloud.TaxonomyResponses.TaxonomyResponse));
+        assert.ok((result instanceof KenticoCloud.TaxonomyResponses.ViewTaxonomyGroupResponse));
     });
 
     it('Response item should be of proper type', () => {


### PR DESCRIPTION
Breaking changes include the refactoring of delivery client configuration.

- `previewApiKey` & ` enablePreviewMode` moved to `previewMode`
- `secureApiKey`  & `enableSecuredMode` moved to `secureMode`
- `baseUrl` & `basePreviewUrl` moved to `proxy`
- `proxyUrl` renamed to `advancedProxyUrlResolver`
- `enableAdvancedLogging` renamed to `isDeveloperMode`

Additionally to this PR, content type related models were fixed as their previous rename was incorrect